### PR TITLE
Add support for cut cheat code

### DIFF
--- a/src/kontrol/kdist/foundry.md
+++ b/src/kontrol/kdist/foundry.md
@@ -119,6 +119,8 @@ The configuration of the Foundry Cheat Codes is defined as follwing:
     - `<isStorageWhitelistActive>` flags if the whitelist mode is enabled for storage changes.
     - `<addressSet>` - stores the address whitelist.
     - `<storageSlotSet>` - stores the storage whitelist containing pairs of addresses and storage indexes.
+6. The `<cutPC>` cell stores a set of program counters inserted using the `cut` cheat code.
+Each program counter in the set will end up creating a new node in the KCFG.
 
 ```k
 module FOUNDRY-CHEAT-CODES
@@ -163,6 +165,7 @@ module FOUNDRY-CHEAT-CODES
           <addressSet> .Set </addressSet>
           <storageSlotSet> .Set </storageSlotSet>
         </whitelist>
+        <cutPC> .Set </cutPC>
       </cheatcodes>
 ```
 
@@ -1035,6 +1038,24 @@ The `ECDSASign` function returns the signed data in [r,s,v] form, which we conve
       requires SELECTOR ==Int selector ( "sign(uint256,bytes32)" )
 ```
 
+
+#### `cut` - Adds a new KCFG node at the given program counter.
+
+```
+function cut(uint256 programCounter) external;
+```
+
+`foundry.call.cut` will match when the `cut` cheat code function is called.
+This rule will add the `programCounter` argument to the `cutPC` set.
+
+```k
+    rule [foundry.call.cut]:
+         <k> #call_foundry SELECTOR ARGS => . ... </k>
+         <cutPC> CPC => CPC SetItem(#asWord(#range(ARGS, 0, 32))) </cutPC>
+      requires SELECTOR ==Int selector ( "cut(uint256)" )
+ ```
+
+
 Otherwise, throw an error for any other call to the Foundry contract.
 
 ```k
@@ -1421,6 +1442,25 @@ If the production is matched when no prank is active, it will be ignored.
         </whitelist>
 ```
 
+- `foundry.pc` triggers the `#cut` rule when a program counter that is in the `cutPC` set is executed.
+
+```k
+    rule [foundry.pc]:
+         <k> #pc [ OP ] => #cut ... </k>
+         <pc> PCOUNT => PCOUNT +Int #widthOp(OP) </pc>
+         <cutPC> CPC </cutPC>
+      requires (PCOUNT +Int #widthOp(OP)) in CPC
+      [priority(40)]
+```
+
+- `foundry_cut` is an empty rule used to create a node in the KCFG.
+
+```k
+    syntax KItem ::= "#cut" [klabel(foundry_cut)]
+ // ---------------------------------------------
+    rule [foundry.cut]: <k> #cut => . ... </k>
+```
+
 - selectors for cheat code functions.
 
 ```k
@@ -1460,6 +1500,7 @@ If the production is matched when no prank is active, it will be ignored.
     rule ( selector ( "allowChangesToStorage(address,uint256)" )   => 4207417100 )
     rule ( selector ( "infiniteGas()" )                            => 3986649939 )
     rule ( selector ( "setGas(uint256)" )                          => 3713137314 )
+    rule ( selector ( "cut(uint256)" )                             => 153488823  )
 ```
 
 - selectors for unimplemented cheat code functions.

--- a/src/kontrol/prove.py
+++ b/src/kontrol/prove.py
@@ -204,13 +204,16 @@ def _run_cfg_group(
                 run_constructor=options.run_constructor,
             )
 
+            cut_point_rules = ['FOUNDRY.foundry.cut']
+            cut_point_rules.extend(KEVMSemantics.cut_point_rules(options.break_on_jumpi, options.break_on_calls))
+
             run_prover(
                 foundry.kevm,
                 proof,
                 kcfg_explore,
                 max_depth=options.max_depth,
                 max_iterations=options.max_iterations,
-                cut_point_rules=KEVMSemantics.cut_point_rules(options.break_on_jumpi, options.break_on_calls),
+                cut_point_rules=cut_point_rules,
                 terminal_rules=KEVMSemantics.terminal_rules(options.break_every_step),
             )
             return proof
@@ -467,6 +470,7 @@ def _init_cterm(
         'ISSTORAGEWHITELISTACTIVE_CELL': FALSE,
         'ADDRESSSET_CELL': KApply('.Set'),
         'STORAGESLOTSET_CELL': KApply('.Set'),
+        'CUTPC_CELL': KApply('.Set'),
     }
 
     constraints = None
@@ -543,6 +547,7 @@ def _final_term(empty_config: KInner, contract_name: str, use_init_code: bool = 
         'ISSTORAGEWHITELISTACTIVE_CELL': KVariable('ISSTORAGEWHITELISTACTIVE_FINAL'),
         'ADDRESSSET_CELL': KVariable('ADDRESSSET_FINAL'),
         'STORAGESLOTSET_CELL': KVariable('STORAGESLOTSET_FINAL'),
+        'CUTPC_CELL': KVariable('CUTPC_FINAL'),
     }
     return abstract_cell_vars(
         Subst(final_subst)(empty_config),
@@ -557,5 +562,6 @@ def _final_term(empty_config: KInner, contract_name: str, use_init_code: bool = 
             KVariable('ISSTORAGEWHITELISTACTIVE_FINAL'),
             KVariable('ADDRESSSET_FINAL'),
             KVariable('STORAGESLOTSET_FINAL'),
+            KVariable('CUTPC_FINAL'),
         ],
     )

--- a/src/tests/integration/test-data/foundry/src/KEVMCheats.sol
+++ b/src/tests/integration/test-data/foundry/src/KEVMCheats.sol
@@ -31,6 +31,8 @@ interface KEVMCheatsBase {
     function freshUInt(uint8) external returns (uint256);
     // Returns a symbolic boolean value
     function freshBool() external returns (uint256);
+    // Adds a new KCFG node at the given program counter.
+     function cut(uint256) external;
 }
 
 abstract contract KEVMCheats {


### PR DESCRIPTION
Fixes: #23 

Added a new cut cheat code that takes a program counter and will create a new KCFG node whenever that program counter is executed.

- When the cut is executed in a proof/test, the program counter argument is added to a set in the <cutPC> cell.
- The #pc [ OP ] rule is overwritten to identify when a program count in the <cutPC> cell is executed.
- Added an empty foundry.cut rule and marked it as a cut-point rule to create the new node in the kcfg.

TODO:

- [ ] add test
- [ ] extract `cut` cheat code in the cheat code library after this PR is merged