### PR TITLE
Enable generating KEVM claims from the basic blocks of Kontrol KCFGs

### DIFF
--- a/src/kontrol/__main__.py
+++ b/src/kontrol/__main__.py
@@ -14,6 +14,7 @@ from pyk.cli.utils import file_path
 from pyk.kbuild.utils import KVersion, k_version
 from pyk.proof.reachability import APRProof
 from pyk.proof.tui import APRProofViewer
+from pyk.utils import ensure_dir_path
 
 from . import VERSION
 from .cli import KontrolCLIArgs
@@ -305,6 +306,7 @@ def exec_show(
     node_deltas: Iterable[tuple[NodeIdLike, NodeIdLike]] = (),
     to_module: bool = False,
     to_kevm_claims: bool = False,
+    kevm_claim_dir: Path | None = None,
     minimize: bool = True,
     sort_collections: bool = False,
     omit_unstable_output: bool = False,
@@ -324,6 +326,7 @@ def exec_show(
         node_deltas=node_deltas,
         to_module=to_module,
         to_kevm_claims=to_kevm_claims,
+        kevm_claim_dir=kevm_claim_dir,
         minimize=minimize,
         omit_unstable_output=omit_unstable_output,
         sort_collections=sort_collections,
@@ -757,6 +760,12 @@ def _create_argument_parser() -> ArgumentParser:
         default=False,
         action='store_true',
         help='Generate a K module which can be run directly as KEVM claims for the given KCFG (best-effort).',
+    )
+    show_args.add_argument(
+        '--kevm-claim-dir',
+        dest='kevm_claim_dir',
+        type=ensure_dir_path,
+        help='Path to write KEVM claim files at.',
     )
 
     command_parser.add_parser(

--- a/src/kontrol/__main__.py
+++ b/src/kontrol/__main__.py
@@ -304,6 +304,7 @@ def exec_show(
     nodes: Iterable[NodeIdLike] = (),
     node_deltas: Iterable[tuple[NodeIdLike, NodeIdLike]] = (),
     to_module: bool = False,
+    to_kevm_claims: bool = False,
     minimize: bool = True,
     sort_collections: bool = False,
     omit_unstable_output: bool = False,
@@ -322,6 +323,7 @@ def exec_show(
         nodes=nodes,
         node_deltas=node_deltas,
         to_module=to_module,
+        to_kevm_claims=to_kevm_claims,
         minimize=minimize,
         omit_unstable_output=omit_unstable_output,
         sort_collections=sort_collections,
@@ -748,6 +750,13 @@ def _create_argument_parser() -> ArgumentParser:
         default=False,
         action='store_true',
         help='Strip output that is likely to change without the contract logic changing',
+    )
+    show_args.add_argument(
+        '--to-kevm-claims',
+        dest='to_kevm_claims',
+        default=False,
+        action='store_true',
+        help='Generate a K module which can be run directly as KEVM claims for the given KCFG (best-effort).',
     )
 
     command_parser.add_parser(

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -16,7 +16,7 @@ from kevm_pyk.kevm import KEVM, KEVMNodePrinter, KEVMSemantics
 from kevm_pyk.utils import byte_offset_to_lines, legacy_explore, print_failure_info, print_model
 from pyk.cterm import CTerm
 from pyk.kast.inner import KApply, KSort, KToken, KVariable
-from pyk.kast.manip import collect, minimize_term
+from pyk.kast.manip import collect, extract_lhs, minimize_term
 from pyk.kast.outer import KDefinition, KFlatModule, KImport, KRequire
 from pyk.kcfg import KCFG
 from pyk.prelude.bytes import bytesToken
@@ -608,6 +608,9 @@ def foundry_show(
 
         claims = [edge.to_rule('BASIC-BLOCK', claim=True) for edge in proof.kcfg.edges()]
         claims = [claim for claim in claims if not _contains_foundry_klabel(claim.body)]
+        claims = [
+            claim for claim in claims if not KEVMSemantics().is_terminal(CTerm.from_kast(extract_lhs(claim.body)))
+        ]
         module = KFlatModule(module_name, sentences=claims, imports=[KImport('VERIFICATION')])
         defn = KDefinition(module_name, [module], requires=[KRequire('verification.k')])
 

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -575,10 +575,21 @@ def foundry_show(
         # Due to bug in KCFG.replace_node: https://github.com/runtimeverification/pyk/issues/686
         proof.kcfg = KCFG.from_dict(proof.kcfg.to_dict())
 
-        module_name = (
+        _module_name = (
             proof.id.upper().replace('%', '-').replace('.', '-').replace('(', '-').replace(')', '-').replace(':', '-')
         )
-        module_name += '-SPEC'
+        _module_name += '-SPEC'
+        module_name = ''
+        is_hyphen = False
+        for char in _module_name:
+            if char == '-':
+                if not is_hyphen:
+                    module_name += char
+                is_hyphen = True
+            else:
+                is_hyphen = False
+                module_name += char
+
         module = proof.kcfg.to_module(module_name=module_name, imports=[KImport('VERIFICATION')])
         new_claims = [
             KClaim(sent.body, requires=sent.requires, ensures=sent.ensures, att=KAtt({'label': sent.label}))

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -622,16 +622,20 @@ def foundry_show(
         claims = [
             claim for claim in claims if not KEVMSemantics().is_terminal(CTerm.from_kast(extract_lhs(claim.body)))
         ]
-        module = KFlatModule(module_name, sentences=claims, imports=[KImport('VERIFICATION')])
-        defn = KDefinition(module_name, [module], requires=[KRequire('verification.k')])
+        if len(claims) == 0:
+            _LOGGER.warning(f'No claims retained for proof {proof.id}')
 
-        defn_lines = foundry.kevm.pretty_print(defn, in_module='EVM').split('\n')
+        else:
+            module = KFlatModule(module_name, sentences=claims, imports=[KImport('VERIFICATION')])
+            defn = KDefinition(module_name, [module], requires=[KRequire('verification.k')])
 
-        res_lines += defn_lines
+            defn_lines = foundry.kevm.pretty_print(defn, in_module='EVM').split('\n')
 
-        if kevm_claim_dir is not None:
-            kevm_claims_file = kevm_claim_dir / (module_name.lower() + '.k')
-            kevm_claims_file.write_text('\n'.join(line.rstrip() for line in defn_lines))
+            res_lines += defn_lines
+
+            if kevm_claim_dir is not None:
+                kevm_claims_file = kevm_claim_dir / (module_name.lower() + '.k')
+                kevm_claims_file.write_text('\n'.join(line.rstrip() for line in defn_lines))
 
     return '\n'.join([line.rstrip() for line in res_lines])
 

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -575,6 +575,11 @@ def foundry_show(
                 '#call_foundry___FOUNDRY-CHEAT-CODES_KItem_Int_Bytes',
                 '#error_foundry___FOUNDRY-CHEAT-CODES_KItem_Int_Bytes',
                 '#return_foundry___FOUNDRY-CHEAT-CODES_KItem_Int_Int',
+                'FOUNDRY_WHITELISTCALL_FOUNDRY-CHEAT-CODES_ExceptionalStatusCode',
+                'FOUNDRY_WHITELISTSTORAGE_FOUNDRY-CHEAT-CODES_ExceptionalStatusCode',
+                '#updateRevertOutput___FOUNDRY-CHEAT-CODES_KItem_Int_Int',
+                '#checkRevert_FOUNDRY-CHEAT-CODES_KItem',
+                '#clearExpectRevert_FOUNDRY-CHEAT-CODES_KItem',
             ]
 
             def _collect_klabel(_k: KInner) -> None:

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -17,7 +17,7 @@ from kevm_pyk.utils import byte_offset_to_lines, legacy_explore, print_failure_i
 from pyk.cterm import CTerm
 from pyk.kast.inner import KApply, KSort, KToken, KVariable
 from pyk.kast.manip import minimize_term
-from pyk.kast.outer import KAtt, KClaim, KFlatModule, KRule
+from pyk.kast.outer import KAtt, KClaim, KDefinition, KFlatModule, KImport, KRequire, KRule
 from pyk.kcfg import KCFG
 from pyk.prelude.bytes import bytesToken
 from pyk.prelude.kbool import notBool
@@ -493,6 +493,7 @@ def foundry_show(
     node_deltas: Iterable[tuple[NodeIdLike, NodeIdLike]] = (),
     to_module: bool = False,
     to_kevm_claims: bool = False,
+    kevm_claim_dir: Path | None = None,
     minimize: bool = True,
     sort_collections: bool = False,
     omit_unstable_output: bool = False,
@@ -574,15 +575,26 @@ def foundry_show(
         # Due to bug in KCFG.replace_node: https://github.com/runtimeverification/pyk/issues/686
         proof.kcfg = KCFG.from_dict(proof.kcfg.to_dict())
 
-        module = proof.kcfg.to_module()
+        module_name = (
+            proof.id.upper().replace('%', '-').replace('.', '-').replace('(', '-').replace(')', '-').replace(':', '-')
+        )
+        module_name += '-SPEC'
+        module = proof.kcfg.to_module(module_name=module_name, imports=[KImport('VERIFICATION')])
         new_claims = [
             KClaim(sent.body, requires=sent.requires, ensures=sent.ensures, att=KAtt({'label': sent.label}))
             for sent in module.sentences
             if type(sent) is KRule
         ]
         module = KFlatModule(module.name, sentences=new_claims, imports=module.imports)
+        defn = KDefinition(module.name, [module], requires=[KRequire('verification.k')])
 
-        res_lines += foundry.kevm.pretty_print(module, in_module='EVM').split('\n')
+        defn_lines = foundry.kevm.pretty_print(defn, in_module='EVM').split('\n')
+
+        res_lines += defn_lines
+
+        if kevm_claim_dir is not None:
+            kevm_claims_file = kevm_claim_dir / (module_name.lower() + '.k')
+            kevm_claims_file.write_text('\n'.join(line.rstrip() for line in defn_lines))
 
     return '\n'.join([line.rstrip() for line in res_lines])
 

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -572,6 +572,7 @@ def foundry_show(
         def _contains_foundry_klabel(_kast: KInner) -> bool:
             _contains = False
             _foundry_labels = [
+                '#call_foundry___FOUNDRY-CHEAT-CODES_KItem_Int_Bytes',
                 '#error_foundry___FOUNDRY-CHEAT-CODES_KItem_Int_Bytes',
                 '#return_foundry___FOUNDRY-CHEAT-CODES_KItem_Int_Int',
             ]

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -605,9 +605,7 @@ def foundry_show(
                 is_hyphen = False
                 module_name += char
 
-        claims = [
-            edge.to_rule(f'BASIC-BLOCK-{edge.source.id}-TO-{edge.target.id}', claim=True) for edge in proof.kcfg.edges()
-        ]
+        claims = [edge.to_rule('BASIC-BLOCK', claim=True) for edge in proof.kcfg.edges()]
         claims = [claim for claim in claims if not _contains_foundry_klabel(claim.body)]
         module = KFlatModule(module_name, sentences=claims, imports=[KImport('VERIFICATION')])
         defn = KDefinition(module_name, [module], requires=[KRequire('verification.k')])

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -592,7 +592,13 @@ def foundry_show(
         proof.kcfg = KCFG.from_dict(proof.kcfg.to_dict())
 
         _module_name = (
-            proof.id.upper().replace('%', '-').replace('.', '-').replace('(', '-').replace(')', '-').replace(':', '-')
+            proof.id.upper()
+            .replace('%', '-')
+            .replace('.', '-')
+            .replace('(', '-')
+            .replace(')', '-')
+            .replace(':', '-')
+            .replace(',', '-')
         )
         _module_name += '-SPEC'
         module_name = ''

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -577,8 +577,9 @@ def foundry_show(
             ]
 
             def _collect_klabel(_k: KInner) -> None:
+                nonlocal _contains
                 if type(_k) is KApply and _k.label.name in _foundry_labels:
-                    pass
+                    _contains = True
 
             collect(_collect_klabel, _kast)
             return _contains


### PR DESCRIPTION
Blocked on: https://github.com/runtimeverification/kontrol/pull/261
Blocked on: https://github.com/runtimeverification/pyk/pull/804

Enables: https://github.com/runtimeverification/evm-semantics/pull/2244

This PR enables generating KEVM specifications directly from the basic blocks of generated Kontrol KCFGs. In particular:

- Option `--to-kevm-claims` to `kontrol show ...` also produces a module containing KEVM claims for each basic block. The basic blocks are turned into claims that should pass without branching on KEVM, with the following massaging:
  - Any claim mentioning symbols from the Foundry modules is stripped out.
  - The claims are made over _only_ the `<kevm>` subconfiguration which is extracted, not over the remaining `<cheat-codes>` configuration.
- Option `--kevm-claim-dir ...` allows specifying a directory to generate these claims in.