### PR TITLE
Initial refactoring of exit codes

### DIFF
--- a/src/kontrol/__main__.py
+++ b/src/kontrol/__main__.py
@@ -70,11 +70,10 @@ def _load_foundry(foundry_root: Path, bug_report: BugReport | None = None, use_h
     try:
         foundry = Foundry(foundry_root=foundry_root, bug_report=bug_report, use_hex_encoding=use_hex_encoding)
     except FileNotFoundError:
-        print(
+        raise RuntimeError(
             f'File foundry.toml not found in: {str(foundry_root)!r}. Are you running kontrol in a Foundry project?',
             file=sys.stderr,
         )
-        sys.exit(1)
     return foundry
 
 
@@ -321,7 +320,6 @@ def exec_prove(
         include_summaries=include_summaries,
         xml_test_report=xml_test_report,
     )
-    failed = 0
     for proof in results:
         _, test = proof.id.split('.')
         if not any(test.startswith(prefix) for prefix in ['test', 'check', 'prove']):
@@ -333,7 +331,6 @@ def exec_prove(
             print(f'PROOF PASSED: {proof.id}')
             print(f'time: {proof.formatted_exec_time()}')
         else:
-            failed += 1
             print(f'PROOF FAILED: {proof.id}')
             print(f'time: {proof.formatted_exec_time()}')
             failure_log = None
@@ -348,7 +345,7 @@ def exec_prove(
                 print(f'The proof cannot be completed while there are refuted nodes: {refuted_nodes}.')
                 print('Either unrefute the nodes or discharge the corresponding refutation subproofs.')
 
-    sys.exit(failed)
+    sys.exit(1)
 
 
 def exec_show(

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -261,8 +261,7 @@ class Foundry:
         try:
             run_process(['forge', 'build', '--build-info', '--root', str(self._root)], logger=_LOGGER)
         except FileNotFoundError:
-            print("Error: 'forge' command not found. Please ensure that 'forge' is installed and added to your PATH.")
-            sys.exit(1)
+            raise RuntimeError("Error: 'forge' command not found. Please ensure that 'forge' is installed and added to your PATH.")
         except CalledProcessError as err:
             raise RuntimeError("Couldn't forge build!") from err
 


### PR DESCRIPTION
Addresses https://github.com/runtimeverification/kontrol/issues/281.

As discussed [on slack](https://runtimeverification.slack.com/archives/C03NP1UP2KZ/p1712427281409899) with @F-WRunTime and @tothtamas28, to facilitate the use of Kontrol on CI, this PR makes the following changes: 
- changes exit code for a `kontrol prove` run with failed tests from the number of failed tests to `1`
- throws a `RuntimeError` if a `forge` invocation fails, instead of returning `1` as before