### PR TITLE
Don't attempt to hex encode contract names

### DIFF
--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -122,7 +122,7 @@ class FoundryKEVM(KEVM):
                     return KApply(_term.label, [DOTS])
             return _term
 
-        if not self.foundry._expand_config and isinstance(kast, KInner):
+        if not self.foundry._expand_config and isinstance(kast, KInner) and not self.use_hex_encoding:
             kast = top_down(_simplify_config, kast)
 
         return super().pretty_print(kast, in_module=in_module, unalias=unalias, sort_collections=sort_collections)

--- a/src/tests/integration/test_foundry_prove.py
+++ b/src/tests/integration/test_foundry_prove.py
@@ -475,7 +475,7 @@ def test_foundry_show_with_hex_encoding(
         ),
     )
 
-    show_res = foundry_show(
+    foundry_show(
         foundry=foundry,
         options=ShowOptions(
             {

--- a/src/tests/integration/test_foundry_prove.py
+++ b/src/tests/integration/test_foundry_prove.py
@@ -435,6 +435,58 @@ def test_foundry_merge_nodes(
     assert_pass(test, single(prove_res))
 
 
+def test_foundry_show_with_hex_encoding(
+    update_expected_output: bool,
+    bug_report: BugReport | None,
+    server: KoreServer,
+    no_use_booster: bool,
+    force_sequential: bool,
+    foundry_root_dir: Path | None,
+    worker_id: str,
+    tmp_path_factory: TempPathFactory,
+) -> None:
+
+    if not foundry_root_dir:
+        if worker_id == 'master':
+            root_tmp_dir = tmp_path_factory.getbasetemp()
+        else:
+            root_tmp_dir = tmp_path_factory.getbasetemp().parent
+
+        foundry_root_dir = root_tmp_dir / 'foundry'
+    foundry = Foundry(foundry_root=foundry_root_dir, use_hex_encoding=True)
+
+    if no_use_booster:
+        pytest.skip()
+
+    test = 'CounterTest.testIncrement()'
+
+    if bug_report is not None:
+        server._populate_bug_report(bug_report)
+
+    foundry_prove(
+        foundry=foundry,
+        options=ProveOptions(
+            {
+                'tests': [(test, None)],
+                'bug_report': bug_report,
+                'port': server.port,
+                'force_sequential': force_sequential,
+            }
+        ),
+    )
+
+    show_res = foundry_show(
+        foundry=foundry,
+        options=ShowOptions(
+            {
+                'test': test,
+                'port': server.port,
+                'nodes': [1, 3, 4, 5, 6, 7, 2],
+            }
+        ),
+    )
+
+
 def test_foundry_merge_loop_heads(
     foundry: Foundry,
     update_expected_output: bool,


### PR DESCRIPTION
Fixes a crash that occurs when viewing proof in `kcfg-view` where the code -> contract name replacement was getting applied where it shouldn't. Would also occur when `--use-hex-encoding` was added. Now the  use_hex_encoding parameter which is always used in `kcfg-view` and optional in `show` will override the simplification behavior.

I tried finding a way to test the `kcfg-view` but the built-in testing capabilities of `textual` seem to rely on being executed in an `async` function (see https://textual.textualize.io/guide/testing/) so I don't see a good way to test the rendering unless we want to add new capabilities to our test suite.

I did add a regression test which catches the crash with foundry show with hex encoding enabled.