### PR TITLE
Change log level to `INFO` for the constraint warning

### DIFF
--- a/src/kontrol/prove.py
+++ b/src/kontrol/prove.py
@@ -1153,8 +1153,8 @@ def _create_cse_accounts(
         if field.data_type.startswith('enum'):
             enum_name = field.data_type.split(' ')[1]
             if enum_name not in foundry.enums:
-                _LOGGER.warning(
-                    f'Skipping adding constraint for {enum_name} because it is not tracked by kontrol. It can be automatically constrained to its possible values by adding --enum-constraints.'
+                _LOGGER.info(
+                    f'Skipping adding constraint for {enum_name} because it is not tracked by Kontrol. It can be automatically constrained to its possible values by adding --enum-constraints.'
                 )
             else:
                 enum_max = foundry.enums[enum_name]

--- a/src/kontrol/solc_to_k.py
+++ b/src/kontrol/solc_to_k.py
@@ -704,8 +704,8 @@ class Contract:
                 if input.internal_type is not None and input.internal_type.startswith('enum '):
                     enum_name = input.internal_type.split(' ')[1]
                     if enum_name not in enums:
-                        _LOGGER.warning(
-                            f'Skipping adding constraint for {enum_name} because it is not tracked by kontrol. It can be automatically constrained to its possible values by adding --enum-constraints.'
+                        _LOGGER.info(
+                            f'Skipping adding constraint for {enum_name} because it is not tracked by Kontrol. It can be automatically constrained to its possible values by adding --enum-constraints.'
                         )
                     else:
                         enum_max = enums[enum_name]


### PR DESCRIPTION
As identified by @JuanCoRo, we're showing the following warning when running `kontrol build` (or `kontrol prove --cse`) on any project importing `forge-std/Test`:
```
WARNING 2024-07-23 13:49:32,885 kontrol.solc_to_k - Skipping adding constraint for VmSafe.ForgeContext because it is not tracked by kontrol. It can be automatically constrained to its possible values by adding --enum-constraints.
WARNING 2024-07-23 13:49:32,918 kontrol.solc_to_k - Skipping adding constraint for VmSafe.ForgeContext because it is not tracked by kontrol. It can be automatically constrained to its possible values by adding --enum-constraints.
```
This PR changes the log info for these warnings to `INFO`, so they're only shown when run with `--verbose`.