### PR TITLE
fix: `requires` instead of `require` for `kontrol init` lemmas.k

### DIFF
--- a/src/kontrol/utils.py
+++ b/src/kontrol/utils.py
@@ -72,7 +72,7 @@ def append_to_file(file_path: Path, content: str) -> None:
 
 
 def empty_lemmas_file_contents() -> str:
-    return """require "foundry.md"
+    return """requires "foundry.md"
 
 module KONTROL-LEMMAS
 

--- a/src/tests/integration/test_kontrol.py
+++ b/src/tests/integration/test_kontrol.py
@@ -61,7 +61,7 @@ def foundry_end_to_end(foundry_root_dir: Path | None, tmp_path_factory: TempPath
             copy_tree(str(TEST_DATA_DIR / 'src'), str(foundry_root / 'test'))
 
             foundry_kompile(
-                BuildOptions({}),
+                BuildOptions({'require': str(foundry_root / 'lemmas.k'), 'module-import': 'TestBase:KONTROL-LEMMAS'}),
                 foundry=Foundry(foundry_root),
             )
 


### PR DESCRIPTION
Fixes typo in generated `lemmas.k` by `kontrol init`