### PR TITLE
Bringing back kore-rpc-command

### DIFF
--- a/src/kontrol/cli.py
+++ b/src/kontrol/cli.py
@@ -230,6 +230,12 @@ class KontrolCLIArgs(KEVMCLIArgs):
             help='Log traces of all simplification and rewrite rule applications.',
         )
         args.add_argument(
+            '--kore-rpc-command',
+            dest='kore_rpc_command',
+            type=str,
+            help='Custom command to start RPC server.',
+        )
+        args.add_argument(
             '--use-booster',
             dest='use_booster',
             default=None,


### PR DESCRIPTION
This PR corrects an accidental erasure of the `kore-rpc-command` parameter done in a previous PR.