### PR TITLE
Display command options on `--debug`

### DIFF
--- a/src/kontrol/__main__.py
+++ b/src/kontrol/__main__.py
@@ -126,8 +126,13 @@ def main() -> None:
         level=_loglevel(args, toml_args),
         format=_LOG_FORMAT,
         handlers=[
-            RichHandler(level='DEBUG', show_level=True, show_time=False, show_path=False, highlighter=NullHighlighter()),
-            RichHandler(level='INFO', show_level=True, show_time=False, show_path=False, highlighter=NullHighlighter()),
+            RichHandler(
+                level=_loglevel(args, toml_args),
+                show_level=False,
+                show_time=False,
+                show_path=False,
+                highlighter=NullHighlighter(),
+            ),
         ],
     )
 
@@ -196,6 +201,8 @@ def exec_solc_to_k(options: SolcToKOptions) -> None:
 
 
 def exec_build(options: BuildOptions) -> None:
+    _LOGGER.debug(options.to_string())
+
     if options.verbose:
         building_message = f'[{_rv_blue()}]:hammer: [bold]Building [{_rv_yellow()}]Kontrol[/{_rv_yellow()}] project[/bold] :hammer:[/{_rv_blue()}]'
     else:
@@ -214,10 +221,10 @@ def exec_build(options: BuildOptions) -> None:
 
 
 def exec_prove(options: ProveOptions) -> None:
+    _LOGGER.debug(options.to_string())
+
     if options.recorded_diff_state_path and options.recorded_dump_state_path:
         raise AssertionError('Provide only one file for recorded state updates')
-
-    _LOGGER.debug(options.to_string())
 
     recorded_diff_entries = (
         read_recorded_state_diff(options.recorded_diff_state_path) if options.recorded_diff_state_path else None

--- a/src/kontrol/__main__.py
+++ b/src/kontrol/__main__.py
@@ -126,7 +126,8 @@ def main() -> None:
         level=_loglevel(args, toml_args),
         format=_LOG_FORMAT,
         handlers=[
-            RichHandler(level='INFO', show_level=False, show_time=False, show_path=False, highlighter=NullHighlighter())
+            RichHandler(level='DEBUG', show_level=True, show_time=False, show_path=False, highlighter=NullHighlighter()),
+            RichHandler(level='INFO', show_level=True, show_time=False, show_path=False, highlighter=NullHighlighter()),
         ],
     )
 
@@ -215,6 +216,8 @@ def exec_build(options: BuildOptions) -> None:
 def exec_prove(options: ProveOptions) -> None:
     if options.recorded_diff_state_path and options.recorded_dump_state_path:
         raise AssertionError('Provide only one file for recorded state updates')
+
+    _LOGGER.debug(options.to_string())
 
     recorded_diff_entries = (
         read_recorded_state_diff(options.recorded_diff_state_path) if options.recorded_diff_state_path else None

--- a/src/kontrol/__main__.py
+++ b/src/kontrol/__main__.py
@@ -201,9 +201,9 @@ def exec_solc_to_k(options: SolcToKOptions) -> None:
 
 
 def exec_build(options: BuildOptions) -> None:
-    _LOGGER.debug(options.to_string())
+    _LOGGER.debug(options)
 
-    if options.verbose:
+    if options.verbose or options.debug:
         building_message = f'[{_rv_blue()}]:hammer: [bold]Building [{_rv_yellow()}]Kontrol[/{_rv_yellow()}] project[/bold] :hammer:[/{_rv_blue()}]'
     else:
         building_message = f'[{_rv_blue()}]:hammer: [bold]Building [{_rv_yellow()}]Kontrol[/{_rv_yellow()}] project[/bold] :hammer: \n Add `--verbose` to `kontrol build` for more details![/{_rv_blue()}]'
@@ -221,7 +221,7 @@ def exec_build(options: BuildOptions) -> None:
 
 
 def exec_prove(options: ProveOptions) -> None:
-    _LOGGER.debug(options.to_string())
+    _LOGGER.debug(options)
 
     if options.recorded_diff_state_path and options.recorded_dump_state_path:
         raise AssertionError('Provide only one file for recorded state updates')
@@ -233,7 +233,7 @@ def exec_prove(options: ProveOptions) -> None:
         read_recorded_state_dump(options.recorded_dump_state_path) if options.recorded_dump_state_path else None
     )
 
-    if options.verbose:
+    if options.verbose or options.debug:
         proving_message = f'[{_rv_blue()}]:person_running: [bold]Running [{_rv_yellow()}]Kontrol[/{_rv_yellow()}] proofs[/bold] :person_running:[/{_rv_blue()}]'
     else:
         proving_message = f'[{_rv_blue()}]:person_running: [bold]Running [{_rv_yellow()}]Kontrol[/{_rv_yellow()}] proofs[/bold] :person_running: \n Add `--verbose` to `kontrol prove` for more details![/{_rv_blue()}]'

--- a/src/kontrol/kompile.py
+++ b/src/kontrol/kompile.py
@@ -132,7 +132,7 @@ def foundry_kompile(
         digest_dict = _read_digest_file(foundry.digest_file)
         digest_dict['kompilation'] = kompilation_digest()
         digest_dict['kontrol'] = VERSION
-        digest_dict['build-options'] = options.to_string()
+        digest_dict['build-options'] = options
         foundry.digest_file.write_text(json.dumps(digest_dict, indent=4))
 
         _LOGGER.info('Updated Kompilation digest')

--- a/src/kontrol/kompile.py
+++ b/src/kontrol/kompile.py
@@ -132,7 +132,7 @@ def foundry_kompile(
         digest_dict = _read_digest_file(foundry.digest_file)
         digest_dict['kompilation'] = kompilation_digest()
         digest_dict['kontrol'] = VERSION
-        digest_dict['build-options'] = options
+        digest_dict['build-options'] = str(options)
         foundry.digest_file.write_text(json.dumps(digest_dict, indent=4))
 
         _LOGGER.info('Updated Kompilation digest')

--- a/src/kontrol/options.py
+++ b/src/kontrol/options.py
@@ -458,7 +458,7 @@ class ProveOptions(
             self.max_depth = 100000
             self.max_iterations = 10000
 
-    def to_string(self) -> str:
+    def __str__(self) -> str:
         """
         Generate a string representation of the instance, including attributes from inherited classes.
 
@@ -466,7 +466,6 @@ class ProveOptions(
         The loop is required to iterate over all parent classes and fetch attributes set by the `default` method.
 
         :return: String representation of the instance.
-        :rtype: str
         """
         options_dict = {**self.__dict__}
 
@@ -855,7 +854,7 @@ class BuildOptions(LoggingOptions, KOptions, KGenOptions, KompileOptions, Foundr
             | KompileTargetOptions.get_argument_type()
         )
 
-    def to_string(self) -> str:
+    def __str__(self) -> str:
         """
         Generate a string representation of the instance, including attributes from inherited classes.
 
@@ -863,7 +862,6 @@ class BuildOptions(LoggingOptions, KOptions, KGenOptions, KompileOptions, Foundr
         The loop is required to iterate over all parent classes and fetch attributes set by the `default` method.
 
         :return: String representation of the instance.
-        :rtype: str
         """
         options_dict = {**self.__dict__}
 

--- a/src/kontrol/options.py
+++ b/src/kontrol/options.py
@@ -458,6 +458,25 @@ class ProveOptions(
             self.max_depth = 100000
             self.max_iterations = 10000
 
+    def to_string(self) -> str:
+        """
+        Generate a string representation of the instance, including attributes from inherited classes.
+
+        The first line collects all attributes that are directly set on the instance.
+        The loop is required to iterate over all parent classes and fetch attributes set by the `default` method.
+
+        :return: String representation of the instance.
+        :rtype: str
+        """
+        options_dict = {**self.__dict__}
+
+        for parent in self.__class__.__bases__:
+            if hasattr(parent, 'default'):
+                options_dict.update(parent.default())
+
+        options_str = ', '.join(f'{key}: {value}' for key, value in options_dict.items())
+        return f'ProveOptions({options_str})'
+
 
 class RefuteNodeOptions(LoggingOptions, FoundryTestOptions, FoundryOptions):
     node: NodeIdLike


### PR DESCRIPTION
- add debug log messages with the options provided to `build` and `prove`.
- add the `to_string()` method for `ProveOptions.`
- update the log handler to use the provided log level; previously, it was hardcoded to `INFO`, preventing the `DEBUG` logs from being displayed.