### PR TITLE
Fix permissions on `keccak.md`

### DIFF
--- a/src/kontrol/kompile.py
+++ b/src/kontrol/kompile.py
@@ -81,7 +81,7 @@ def foundry_kompile(
                 # Fetch current permissions
                 current_permissions = Path.stat(req_path).st_mode
                 # Grant write permissions
-                Path.chmod(req_path, current_permissions | Path.stat.S_IWUSR | Path.stat.S_IWGRP | Path.stat.S_IWOTH)
+                req_path.chmod(current_permissions | Path.stat.S_IWUSR | Path.stat.S_IWGRP | Path.stat.S_IWOTH)
             regen = True
 
     _imports: dict[str, list[str]] = {contract.name_with_path: [] for contract in foundry.contracts.values()}

--- a/src/kontrol/kompile.py
+++ b/src/kontrol/kompile.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shutil
+import stat
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -75,6 +77,12 @@ def foundry_kompile(
         if regen or not req_path.exists():
             _LOGGER.info(f'Copying requires path: {req} -> {req_path}')
             shutil.copy(req, req_path)
+            # If the copied file is not writeable
+            if not os.access(req_path, os.W_OK):
+                # Fetch current permissions
+                current_permissions = os.stat(req_path).st_mode
+                # Grant write permissions
+                os.chmod(req_path, current_permissions | stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
             regen = True
 
     _imports: dict[str, list[str]] = {contract.name_with_path: [] for contract in foundry.contracts.values()}

--- a/src/kontrol/kompile.py
+++ b/src/kontrol/kompile.py
@@ -79,7 +79,7 @@ def foundry_kompile(
             # If the copied file is not writeable
             if not os.access(req_path, os.W_OK):
                 # Fetch current permissions
-                current_permissions = Path.stat(req_path).st_mode
+                current_permissions = req_path.stat().st_mode
                 # Grant write permissions
                 req_path.chmod(current_permissions | Path.stat.S_IWUSR | Path.stat.S_IWGRP | Path.stat.S_IWOTH)
             regen = True

--- a/src/kontrol/kompile.py
+++ b/src/kontrol/kompile.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import shutil
-import stat
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -80,9 +79,9 @@ def foundry_kompile(
             # If the copied file is not writeable
             if not os.access(req_path, os.W_OK):
                 # Fetch current permissions
-                current_permissions = os.stat(req_path).st_mode
+                current_permissions = Path.stat(req_path).st_mode
                 # Grant write permissions
-                os.chmod(req_path, current_permissions | stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+                Path.chmod(req_path, current_permissions | Path.stat.S_IWUSR | Path.stat.S_IWGRP | Path.stat.S_IWOTH)
             regen = True
 
     _imports: dict[str, list[str]] = {contract.name_with_path: [] for contract in foundry.contracts.values()}

--- a/src/kontrol/kompile.py
+++ b/src/kontrol/kompile.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import shutil
+import stat
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -81,7 +82,7 @@ def foundry_kompile(
                 # Fetch current permissions
                 current_permissions = req_path.stat().st_mode
                 # Grant write permissions
-                req_path.chmod(current_permissions | Path.stat.S_IWUSR | Path.stat.S_IWGRP | Path.stat.S_IWOTH)
+                req_path.chmod(current_permissions | stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
             regen = True
 
     _imports: dict[str, list[str]] = {contract.name_with_path: [] for contract in foundry.contracts.values()}


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/runtimeverification/kontrol/pull/779 by making `out/kompiled/requires/keccak.md` (and any other filed copied to `requires` in future) writeable for the current user, group, and others (anyone with access to the file).

The files have to writeable so they can be deleted and replaced when `kontrol build --rekompile` is executed. The files not copied from `kontrol/kdist` had write access previously, but the ones we are now copying from `kdist` (such as `keccak.md`) don't, which  causes issues such as this one:

```
INFO 2024-08-23 08:58:19,927 kontrol.kompile - Copying requires path: /nix/store/g67pca4v4lx9zgna190kdwvrj4n0jarm-python3.10-kontrol-0.1.409/lib/python3.10/site-packages/kontrol/kdist/keccak.md ->                           
out/kompiled/requires/keccak.md                                                                                                                                                                                                
An error occurred while building your Kontrol project: [Errno 13] Permission denied: 'out/kompiled/requires/keccak.md'
```