### PR TITLE
Fix iterating over 'linkReferences' in solc to k

### DIFF
--- a/src/kontrol/solc_to_k.py
+++ b/src/kontrol/solc_to_k.py
@@ -755,7 +755,7 @@ class Contract:
         self.link_ranges = [
             (rng['start'], rng['length'])
             for ref in deployed_bytecode.get('linkReferences', {}).values()
-            for rng_grp in ref
+            for rng_grp in ref.values()
             for rng in rng_grp
         ]
 


### PR DESCRIPTION
processing a structure such as the one below will trigger a `string indices must be integers` error.
```json
{
    "linkReferences": {
        "test/foundry/util/TestUtil.sol": {
            "TestUtil": [
                {
                    "start": 1443,
                    "length": 20
                }
            ]
        }
    }
}
```

The line `for rng_grp in ref` assumes that `ref` is directly iterable as if it were a `list`. However, `ref` is actually a dictionary, and directly iterating over it would yield the keys (in this case, "TestUtil"), which are `strings`.