### PR TITLE
Option to emit summaries as rules instead of claims

### DIFF
--- a/src/kontrol/cli.py
+++ b/src/kontrol/cli.py
@@ -606,6 +606,13 @@ def _create_argument_parser() -> ArgumentParser:
         help='Generate a K module which can be run directly as KEVM claims for the given KCFG (best-effort).',
     )
     show_args.add_argument(
+        '--to-kevm-rules',
+        dest='to_kevm_rules',
+        default=None,
+        action='store_true',
+        help='Generate a K module which can be used to optimize KEVM execution (best-effort).',
+    )
+    show_args.add_argument(
         '--kevm-claim-dir',
         dest='kevm_claim_dir',
         type=ensure_dir_path,

--- a/src/kontrol/options.py
+++ b/src/kontrol/options.py
@@ -571,6 +571,7 @@ class ShowOptions(
 ):
     omit_unstable_output: bool
     to_kevm_claims: bool
+    to_kevm_rules: bool
     kevm_claim_dir: Path | None
     use_hex_encoding: bool
     expand_config: bool
@@ -580,6 +581,7 @@ class ShowOptions(
         return {
             'omit_unstable_output': False,
             'to_kevm_claims': False,
+            'to_kevm_rules': False,
             'kevm_claim_dir': None,
             'use_hex_encoding': False,
             'counterexample_info': True,

--- a/src/kontrol/prove.py
+++ b/src/kontrol/prove.py
@@ -16,6 +16,7 @@ from pyk.cterm import CTerm, CTermSymbolic
 from pyk.kast.inner import KApply, KSequence, KSort, KVariable, Subst
 from pyk.kast.manip import flatten_label, set_cell
 from pyk.kcfg import KCFG, KCFGExplore
+from pyk.kcfg.minimize import KCFGMinimizer
 from pyk.kore.rpc import KoreClient, TransportType, kore_server
 from pyk.prelude.bytes import bytesToken
 from pyk.prelude.collections import list_empty, map_empty, map_item, map_of, set_empty
@@ -730,7 +731,7 @@ def _method_to_cfg(
         # Copy KCFG and minimize it
         if graft_setup_proof:
             cfg = KCFG.from_dict(setup_proof.kcfg.to_dict())
-            cfg.minimize()
+            KCFGMinimizer(cfg).minimize()
             cfg.remove_node(setup_proof.target)
         else:
             cfg = KCFG()


### PR DESCRIPTION
Blocked on: https://github.com/runtimeverification/k/pull/4610

This adds the option `--to-kevm-rules` as a complement of `--to-kevm-claims` to `kontrol show ...`. This allows the user to generate summary rules that can be rekompiled into the semantics for use with the LLVM backend.