### PR TITLE
Move helper functions to utils file

### DIFF
--- a/src/kontrol/utils.py
+++ b/src/kontrol/utils.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 import json
+import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pyk
+from pyk.kbuild.utils import KVersion, k_version
+
 if TYPE_CHECKING:
-    from pathlib import Path
+    from typing import Final
+    from argparse import Namespace
 
 import os
 import stat
@@ -14,6 +20,58 @@ from rich.console import Console
 from . import VERSION
 
 console = Console()
+
+_LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
+_LOGGER: Final = logging.getLogger(__name__)
+
+
+def check_k_version() -> None:
+    expected_k_version = KVersion.parse(f'v{pyk.__version__}')
+    actual_k_version = k_version()
+
+    if not _compare_versions(expected_k_version, actual_k_version):
+        _LOGGER.warning(
+            f'K version {expected_k_version.text} was expected but K version {actual_k_version.text} is being used.'
+        )
+
+
+def _compare_versions(ver1: KVersion, ver2: KVersion) -> bool:
+    if ver1.major != ver2.major or ver1.minor != ver2.minor or ver1.patch != ver2.patch:
+        return False
+
+    if ver1.git == ver2.git:
+        return True
+
+    if ver1.git and ver2.git:
+        return False
+
+    git = ver1.git or ver2.git
+    assert git  # git is not None for exactly one of ver1 and ver2
+    return not git.ahead and not git.dirty
+
+
+def config_file_path(args: Namespace) -> Path:
+    return (
+        Path.joinpath(
+            Path('.') if not getattr(args, 'foundry_root', None) else args.foundry_root,
+            'kontrol.toml',
+        )
+        if not getattr(args, 'config_file', None)
+        else args.config_file
+    )
+
+
+def loglevel(args: Namespace, toml_args: dict) -> int:
+    def is_attr_used(attr_name: str) -> bool | None:
+        return getattr(args, attr_name, None) or toml_args.get(attr_name)
+
+    if is_attr_used('debug'):
+        return logging.DEBUG
+
+    if is_attr_used('verbose'):
+        return logging.INFO
+
+    return logging.WARNING
 
 
 def _read_digest_file(digest_file: Path) -> dict:


### PR DESCRIPTION
Cleaning up `__main__.py` a bit:
Moving helper functions to `kontrol.utils` module:
 - `_LOG_FORMAT`
 - `_check_k_version`
 - `_compare_versions`
 - `_loglevel`
 - `_config_file_path`

Removing unused function: `_ignore_arg`