### PR TITLE
Add transient storage test to e2e tests

### DIFF
--- a/src/kontrol/utils.py
+++ b/src/kontrol/utils.py
@@ -248,6 +248,12 @@ extra_output = ['storageLayout']
 """
 
 
+def foundry_toml_cancun_schedule() -> str:
+    return """
+evm_version = "cancun"
+"""
+
+
 def _rv_yellow() -> str:
     return '#ffcc07'
 

--- a/src/tests/integration/test-data/end-to-end-prove-all
+++ b/src/tests/integration/test-data/end-to-end-prove-all
@@ -1,4 +1,5 @@
 CounterTest.test_Increment()
+TransientStorageTest.testTransientStoreLoad(uint256,uint256)
 UnitTest.test_assertEq_address_err()
 UnitTest.test_assertEq_bool_err()
 UnitTest.test_assertEq_bytes32_err()

--- a/src/tests/integration/test-data/src/TransientStorage.t.sol
+++ b/src/tests/integration/test-data/src/TransientStorage.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+
+contract TransientStorageTest is Test {
+    function testTransientStoreLoad(uint256 key, uint256 value) public {
+        // Store `value` at `key` in transient storage
+        assembly {
+            tstore(key, value)
+        }
+
+        uint256 loadedValue;
+
+        // Load `value` from `key` in transient storage        
+        assembly {
+            loadedValue := tload(key)
+        }
+
+        assertEq(loadedValue, value, "TLOAD did not return the correct value");
+    }
+}

--- a/src/tests/integration/test_kontrol.py
+++ b/src/tests/integration/test_kontrol.py
@@ -13,6 +13,7 @@ from kontrol.foundry import Foundry, init_project
 from kontrol.kompile import foundry_kompile
 from kontrol.options import BuildOptions, ProveOptions
 from kontrol.prove import foundry_prove
+from kontrol.utils import foundry_toml_cancun_schedule, write_to_file
 
 from .utils import TEST_DATA_DIR, assert_pass
 
@@ -59,6 +60,7 @@ def foundry_end_to_end(foundry_root_dir: Path | None, tmp_path_factory: TempPath
         if not foundry_root.is_dir():
             init_project(project_root=foundry_root, skip_forge=False)
             copy_tree(str(TEST_DATA_DIR / 'src'), str(foundry_root / 'test'))
+            write_to_file(TEST_DATA_DIR / 'foundry.toml', foundry_toml_cancun_schedule())
 
             foundry_kompile(
                 BuildOptions(


### PR DESCRIPTION
This PR adds Cancun schedule, transient storage test to end-to-end tests.