### PR TITLE
Fixed `--init-node-from-diff` and `init-node-from-dump`

### DIFF
--- a/src/kontrol/options.py
+++ b/src/kontrol/options.py
@@ -446,7 +446,8 @@ class ProveOptions(
             | EVMChainOptions.get_argument_type()
             | {
                 'match-test': list_of(parse_test_version_tuple),
-                'init-node-from': file_path,
+                'init-node-from-diff': file_path,
+                'init-node-from-dump': file_path,
                 'include-summary': list_of(parse_test_version_tuple),
             }
         )


### PR DESCRIPTION
`--init-node-from` has been split into `--init-node-from-diff` and `--init-node-from-dump`. However, the function `get_argument_type` was not refactored to reflect that change and still only defined `init-node-from`  as a `path` type, but not `init-node-from-diff` or `init-node-from-dump`.  This PR fixes that function.

Closes #813.