### PR TITLE
Use  `build_info_path` in `load_build_info`, update TOML parsing logic

### DIFF
--- a/src/kontrol/__main__.py
+++ b/src/kontrol/__main__.py
@@ -312,7 +312,7 @@ def exec_view_kcfg(options: ViewKcfgOptions) -> None:
     contract_name, _ = test_id.split('.')
     proof = foundry.get_apr_proof(test_id)
 
-    compilation_unit = CompilationUnit.load_build_info(options.foundry_root)
+    compilation_unit = CompilationUnit.load_build_info(foundry.build_info)
 
     def _short_info(cterm: CTerm) -> Iterable[str]:
         return foundry.short_info_for_contract(contract_name, cterm)

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -182,10 +182,10 @@ class Foundry:
     @property
     def profile(self) -> dict[str, Any]:
         profile_name = os.getenv('FOUNDRY_PROFILE', default='default')
-        
+
         current_profile = self._toml['profile'].get(profile_name, {})
         default_profile = self._toml['profile'].get('default', {})
-        
+
         return {**default_profile, **current_profile}
 
     @property

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -218,7 +218,12 @@ class Foundry:
 
     @property
     def build_info(self) -> Path:
-        return self._root / self.profile.get('build_info_path', '')
+        build_info_path = self.profile.get('build_info_path')
+
+        if build_info_path:
+            return self._root / build_info_path
+        else:
+            return self.out / 'build-info'
 
     @cached_property
     def kevm(self) -> KEVM:

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -182,7 +182,11 @@ class Foundry:
     @property
     def profile(self) -> dict[str, Any]:
         profile_name = os.getenv('FOUNDRY_PROFILE', default='default')
-        return self._toml['profile'][profile_name]
+        
+        current_profile = self._toml['profile'].get(profile_name, {})
+        default_profile = self._toml['profile'].get('default', {})
+        
+        return {**default_profile, **current_profile}
 
     @property
     def out(self) -> Path:

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -212,6 +212,10 @@ class Foundry:
     def contracts_file(self) -> Path:
         return self.kompiled / 'contracts.k'
 
+    @property
+    def build_info(self) -> Path:
+        return self._root / self.profile.get('build_info_path', '')
+
     @cached_property
     def kevm(self) -> KEVM:
         use_directory = self.out / 'tmp'
@@ -1364,7 +1368,7 @@ class FoundryNodePrinter(KEVMNodePrinter):
         self.foundry = foundry
         self.contract_name = contract_name
         self.omit_unstable_output = omit_unstable_output
-        self.compilation_unit = CompilationUnit.load_build_info(foundry._root)
+        self.compilation_unit = CompilationUnit.load_build_info(foundry.build_info)
 
     def print_node(self, kcfg: KCFG, node: KCFG.Node) -> list[str]:
         ret_strs = super().print_node(kcfg, node)

--- a/src/kontrol/solc.py
+++ b/src/kontrol/solc.py
@@ -495,8 +495,8 @@ class CompilationUnit:
         return self._id
 
     @staticmethod
-    def load_build_info(foundry_root: Path) -> CompilationUnit:
-        build_info_files = (foundry_root / 'out' / 'build-info').glob('*.json')
+    def load_build_info(foundry_build_info: Path) -> CompilationUnit:
+        build_info_files = foundry_build_info.glob('*.json')
         build_info = json.loads(max(build_info_files, key=os.path.getmtime).read_text())
         sources: dict[int, Source] = {}  # Source id => Source
         contracts: dict[bytes, ContractSource] = {}  # CBOR metadata => contract


### PR DESCRIPTION
This PR addresses the 
```
  File "/Users/palina/rv/kontrol/src/kontrol/solc.py", line 501, in load_build_info
    build_info = json.loads(max(build_info_files, key=os.path.getmtime).read_text())
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: max() iterable argument is empty
```
error which occurs if the project uses a non-default `build_info_path` in `foundry.toml`:
```toml
[profile.default]
src = "src"
out = "out"
libs = ["lib"]
build_info_path = 'artifacts/build-info'
extra_output = ['storageLayout']

[profile.kontrol-properties]
out = 'out-kontrol-properties'
```

In addition, it also updates the `profile` function in `foundry.py` so that if the key is not defined in the current profile but it is set in the `default` profile, the `default` value (and not an empty string) is used:
```py
    @property
    def profile(self) -> dict[str, Any]:
        profile_name = os.getenv('FOUNDRY_PROFILE', default='default')

        current_profile = self._toml['profile'].get(profile_name, {})
        default_profile = self._toml['profile'].get('default', {})

        return {**default_profile, **current_profile}
```