### PR TITLE
Increase `update-expected-output` timeout

### DIFF
--- a/.github/workflows/update-expected-output.yml
+++ b/.github/workflows/update-expected-output.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.ref != 'refs/heads/master'
     name: 'Update Kontrol expected output'
     runs-on: [self-hosted, linux, normal, fast]
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR bumps the timeout of the CI job updating expected output to 90 minutes.