### PR TITLE
CSE: constrain `address` and `contract` field and parameters

### DIFF
--- a/src/kontrol/prove.py
+++ b/src/kontrol/prove.py
@@ -1216,6 +1216,19 @@ def _create_cse_accounts(
                 address_range_ub = ltInt(field_variable, intToken(1461501637330902918203684832716283019655932542976))
                 new_account_constraints.append(mlEqualsTrue(address_range_lb))
                 new_account_constraints.append(mlEqualsTrue(address_range_ub))
+                # Address is not the cheatcode contract address
+                new_account_constraints.append(
+                    mlEqualsFalse(
+                        KApply(
+                            '_==Int_',
+                            [
+                                field_variable,
+                                Foundry.address_CHEATCODE(),
+                            ],
+                        )
+                    )
+                )
+                # TODO(palina): assume it's not a precompiled address
         # Processing of contracts
         if field.data_type.startswith('contract '):
             if field.linked_interface:


### PR DESCRIPTION
Closes https://github.com/runtimeverification/kontrol/issues/827.

During CSE, this PR:
- adds an assumption that an `address` field (not just `contract` field) is not a `Vm` cheatcode address 
- TODO: adds an assumption that it's not a precompiled address
- TODO: adds similar assumptions to function parameters