### PR TITLE
Optimization flags for kontrol build

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -198,7 +198,7 @@ jobs:
           docker exec --user ${DOCKER_USER} --workdir ${FOUNDRY_ROOT} ${CONTAINER_NAME} forge install --no-git runtimeverification/kontrol-cheatcodes@a5dd4b0
           docker exec --user ${DOCKER_USER} --workdir ${FOUNDRY_ROOT} ${CONTAINER_NAME} forge build
       - name: 'Run kontrol build'
-        run: docker exec --user ${DOCKER_USER} --workdir ${FOUNDRY_ROOT} ${CONTAINER_NAME} kontrol build
+        run: docker exec --user ${DOCKER_USER} --workdir ${FOUNDRY_ROOT} ${CONTAINER_NAME} kontrol build -O2
       - name: 'Run kontrol prove'
         run: docker exec --user ${DOCKER_USER} --workdir ${FOUNDRY_ROOT} ${CONTAINER_NAME} kontrol prove --match-test 'AssertTest.test_assert_true()'
       - name: 'Run kontrol show'

--- a/src/kontrol/kompile.py
+++ b/src/kontrol/kompile.py
@@ -160,6 +160,15 @@ def foundry_kompile(
 
     if should_rekompile():
         output_dir = foundry.kompiled
+
+        optimization = 0
+        if options.o1:
+            optimization = 1
+        if options.o2:
+            optimization = 2
+        if options.o3:
+            optimization = 3
+
         kevm_kompile(
             target=options.target,
             output_dir=output_dir,
@@ -172,6 +181,7 @@ def foundry_kompile(
             debug=options.debug,
             verbose=options.verbose,
             ignore_warnings=options.ignore_warnings,
+            optimization=optimization,
         )
 
     update_kompilation_digest()


### PR DESCRIPTION
The `-O{0,1,2,3}` flags for `kontrol build` aren't working. This fixes that by passing them along to the call to `kevm_kompile`.