### PR TITLE
Add `setUp` and `init` to XML report

### DIFF
--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -959,16 +959,6 @@ def foundry_list(foundry: Foundry) -> list[str]:
     return lines
 
 
-def setup_exec_time(foundry: Foundry, contract: Contract) -> float:
-    setup_exec_time = 0.0
-    if 'setUp' in contract.method_by_name:
-        latest_version = foundry.latest_proof_version(f'{contract.name_with_path}.setUp()')
-        setup_digest = f'{contract.name_with_path}.setUp():{latest_version}'
-        apr_proof = APRProof.read_proof_data(foundry.proofs_dir, setup_digest)
-        setup_exec_time = apr_proof.exec_time
-    return setup_exec_time
-
-
 def foundry_to_xml(foundry: Foundry, proofs: list[APRProof]) -> None:
     testsuites = Et.Element(
         'testsuites', tests='0', failures='0', errors='0', time='0', timestamp=str(datetime.datetime.now())
@@ -985,7 +975,6 @@ def foundry_to_xml(foundry: Foundry, proofs: list[APRProof]) -> None:
         proof_exec_time = proof.exec_time
         testsuite = testsuites.find(f'testsuite[@name={contract_name!r}]')
         if testsuite is None:
-            proof_exec_time += setup_exec_time(foundry, foundry_contract)
             testsuite = Et.SubElement(
                 testsuites,
                 'testsuite',


### PR DESCRIPTION
Closes https://github.com/runtimeverification/kontrol/issues/858.

This PR adds `init` and `setUp` proofs to the list of proofs listed in the XML report, instead of adding `setUp` execution time  to test proofs. The resulting report looks, e.g., like this:
```
<testsuites tests="3" failures="0" errors="0" time="205.4912703037262" timestamp="2024-10-09 19:12:54.901543">
	<testsuite name="CounterTest" tests="3" failures="0" errors="0" time="205.4912703037262" timestamp="2024-10-09 19:12:54.901605">
		<properties>
			<property name="Kontrol version" value="1.0.0" />
		</properties>
		<testcase name="init" classname="CounterTest" time="56.86072325706482" file="test/Counter.t.sol" />
		<testcase name="setUp()" classname="CounterTest" time="66.72285008430481" file="test/Counter.t.sol" />
		<testcase name="testFuzz_SetNumber(uint256)" classname="CounterTest" time="81.90769696235657" file="test/Counter.t.sol" />
	</testsuite>
</testsuites>
```