### PR TITLE
Pretty print function arguments in calldata

### DIFF
--- a/src/kontrol/solc_to_k.py
+++ b/src/kontrol/solc_to_k.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, NamedTuple
 from kevm_pyk.kevm import KEVM
 from pyk.kast.att import Atts, KAtt
 from pyk.kast.inner import KApply, KLabel, KRewrite, KSort, KVariable
-from pyk.kast.manip import abstract_term_safely
 from pyk.kast.outer import KDefinition, KFlatModule, KImport, KNonTerminal, KProduction, KRequire, KRule, KTerminal
 from pyk.kdist import kdist
 from pyk.prelude.kbool import TRUE, andBool
@@ -425,11 +424,7 @@ class Contract:
 
         @cached_property
         def callvalue_cell(self) -> KInner:
-            return (
-                intToken(0)
-                if not self.payable
-                else abstract_term_safely(KVariable('_###CALLVALUE###_'), base_name='CALLVALUE')
-            )
+            return intToken(0) if not self.payable else KVariable('CALLVALUE')
 
         def encoded_args(self, enums: dict[str, int]) -> tuple[KInner, list[KInner]]:
             args: list[KInner] = []
@@ -742,11 +737,7 @@ class Contract:
 
         @cached_property
         def callvalue_cell(self) -> KInner:
-            return (
-                intToken(0)
-                if not self.payable
-                else abstract_term_safely(KVariable('_###CALLVALUE###_'), base_name='CALLVALUE')
-            )
+            return intToken(0) if not self.payable else KVariable('CALLVALUE')
 
         def calldata_cell(self, contract: Contract) -> KInner:
             return KApply(contract.klabel_method, [KApply(contract.klabel), self.application])
@@ -755,10 +746,7 @@ class Contract:
         def application(self) -> KInner:
             klabel = self.klabel
             assert klabel is not None
-            args = [
-                abstract_term_safely(KVariable('_###SOLIDITY_ARG_VAR###_'), base_name=f'V{name}')
-                for name in self.arg_names
-            ]
+            args = [KVariable(name) for name in self.arg_names]
             return klabel(args)
 
     _name: str

--- a/src/tests/unit/test_solc_to_k.py
+++ b/src/tests/unit/test_solc_to_k.py
@@ -135,6 +135,7 @@ def test_escaping(test_id: str, prefix: str, input: str, output: str) -> None:
 
 INPUT_DATA: list[tuple[str, Input, KApply]] = [
     ('single_type', Input('RV', 'uint256'), KApply('abi_type_uint256', [KVariable('V0_RV')])),
+    ('single_type', Input('_x', 'uint256'), KApply('abi_type_uint256', [KVariable('V0__x')])),
     (
         'empty_tuple',
         Input('EmptyStruct', 'tuple'),


### PR DESCRIPTION
[abstract_term_safely](https://github.com/runtimeverification/k/blob/5c84d48f697b73ad779395c53b7edc934ed4e8f5/pyk/src/pyk/kast/manip.py#L603) was called for each call data function argument. The same hash of `_###SOLIDITY_ARG_VAR###_` was appended to each variable name as `V{input.arg_name()}_hash`. `Input.arg_name` is already sanitizing the name by prefixing it with `V{index}_`.

The internal representation looks like `name` => `VV0_name_114b9705`.
This PR is currently changing the internal representation to just `V0_name`.