### PR TITLE
Re-raise build errors instead of silently failing

### DIFF
--- a/src/kontrol/__main__.py
+++ b/src/kontrol/__main__.py
@@ -183,6 +183,7 @@ def exec_build(options: BuildOptions) -> None:
         )
     except Exception as e:
         console.print(f'[bold red]An error occurred while building your Kontrol project:[/bold red] [black]{e}[/black]')
+        raise e
 
 
 def exec_prove(options: ProveOptions) -> None:


### PR DESCRIPTION
Currently on build errors that result in exceptions, we just swallow them and continue.

This re-raises the exception.