### PR TITLE
Propagate `forge build` error message to `kontrol build` output

### DIFF
--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -421,7 +421,7 @@ class Foundry:
                 "Error: 'forge' command not found. Please ensure that 'forge' is installed and added to your PATH."
             ) from err
         except CalledProcessError as err:
-            raise RuntimeError("Couldn't forge build!") from err
+            raise RuntimeError(f"Couldn't forge build! Error: {err.stderr.strip()}") from err
 
     @cached_property
     def all_tests(self) -> list[str]:

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -421,7 +421,7 @@ class Foundry:
                 "Error: 'forge' command not found. Please ensure that 'forge' is installed and added to your PATH."
             ) from err
         except CalledProcessError as err:
-            raise RuntimeError(f"Couldn't forge build! Error: {err.stderr.strip()}") from err
+            raise RuntimeError(f"Couldn't forge build! {err.stderr.strip()}") from err
 
     @cached_property
     def all_tests(self) -> list[str]:


### PR DESCRIPTION
This PR includes the error message produced by `forge build` into the `kontrol build` output:
```
❯ poetry run kontrol build --foundry-project-root ../kontrol-dss-demo
🔨 Building Kontrol project 🔨 
 Add `--verbose` to `kontrol build` for more details!
An error occurred while building your Kontrol project: Couldn't forge build! Error: Compiler run failed:
Error (7576): Undeclared identifier.
  --> test/AnotherTest.t.sol:12:9:
   |
12 |         a = 11;
   |         ^
Traceback (most recent call last):
  File "/Users/palina/rv/kontrol/src/kontrol/foundry.py", line 415, in build
    run_process_2(
  File "/Users/palina/Library/Caches/pypoetry/virtualenvs/kontrol-1eBmlv-c-py3.12/lib/python3.12/site-packages/pyk/utils.py", line 527, in run_process_2
    res.check_returncode()
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/subprocess.py", line 502, in check_returncode
    raise CalledProcessError(self.returncode, self.args, self.stdout,
subprocess.CalledProcessError: Command '('forge', 'build', '--build-info', '--extra-output', 'storageLayout', 'evm.bytecode.generatedSources', 'evm.deployedBytecode.generatedSources', '--root', '../kontrol-dss-demo')' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/palina/rv/kontrol/src/kontrol/__main__.py", line 130, in main
    execute(options)
  File "/Users/palina/rv/kontrol/src/kontrol/__main__.py", line 175, in exec_build
    raise e
  File "/Users/palina/rv/kontrol/src/kontrol/__main__.py", line 166, in exec_build
    foundry_kompile(
  File "/Users/palina/rv/kontrol/src/kontrol/kompile.py", line 49, in foundry_kompile
    foundry.build(options.metadata)
  File "/Users/palina/rv/kontrol/src/kontrol/foundry.py", line 424, in build
    raise RuntimeError(f"Couldn't forge build! {err.stderr.strip()}") from err
RuntimeError: Couldn't forge build! Error: Compiler run failed:
Error (7576): Undeclared identifier.
  --> test/AnotherTest.t.sol:12:9:
   |
12 |         a = 11;
   |         ^
```