### PR TITLE
Add a rule removing init code size limit checks

### DIFF
--- a/src/kontrol/kdist/no_code_size_checks.md
+++ b/src/kontrol/kdist/no_code_size_checks.md
@@ -12,7 +12,8 @@ module NO-CODE-SIZE-CHECKS
     imports EVM
     imports FOUNDRY
 
-    rule <k> #mkCodeDeposit ACCT
+    rule [deploy-no-codesize-limit]:
+         <k> #mkCodeDeposit ACCT
           => Gcodedeposit < SCHED > *Int lengthBytes(OUT) ~> #deductGas
           ~> #finishCodeDeposit ACCT OUT
          ...
@@ -21,6 +22,24 @@ module NO-CODE-SIZE-CHECKS
          <output> OUT => .Bytes </output>
       requires #isValidCode(OUT, SCHED)
    [priority(30)]
+
+    rule [create-valid-no-codesize-limit]:
+         <k> CREATE VALUE MEMSTART MEMWIDTH
+          => #accessAccounts #newAddr(ACCT, NONCE)
+          ~> #checkCreate ACCT VALUE
+          ~> #create ACCT #newAddr(ACCT, NONCE) VALUE #range(LM, MEMSTART, MEMWIDTH)
+          ~> #codeDeposit #newAddr(ACCT, NONCE)
+         ...
+         </k>
+         <id> ACCT </id>
+         <localMem> LM </localMem>
+         <account>
+           <acctID> ACCT </acctID>
+           <nonce> NONCE </nonce>
+           ...
+         </account>
+         <schedule> SCHED </schedule>
+      [preserves-definedness, priority(30)]
 
 endmodule
 ```


### PR DESCRIPTION
Follow up to https://github.com/runtimeverification/kontrol/pull/897.

This PR adds a rule that removes a code size limit check on the initialization bytecode during deployment by overriding the original one.

Otherwise, if the contract getting deployed is sufficiently big, [this rule](https://github.com/runtimeverification/evm-semantics/blob/b69a4cf43996cf56b5a742150abdd0b4183962e9/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md?plain=1#L1720) kicks in:
```
    rule [create-invalid]:
         <k> CREATE _ _ _ => #end EVMC_OUT_OF_GAS ... </k> [owise]
```
reporting an `EVMC_OUT_OF_GAS` error, even though we aren't checking 

The check that the code getting deployed is not passing is this one:
```
rule #hasValidInitCode(INITCODELEN, SCHED) => notBool Ghasmaxinitcodesize << SCHED >> orBool INITCODELEN <=Int maxInitCodeSize < SCHED >
```
and, for Shanghai (and Cancun), the code limit for the initialization bytecode it's twice the runtime code size limit:
```
rule maxInitCodeSize   < SHANGHAI > => 2 *Int maxCodeSize < SHANGHAI >
```