### PR TITLE
Turn on `O2` by default, add it to `kontrol.toml`

### DIFF
--- a/src/kontrol/cli.py
+++ b/src/kontrol/cli.py
@@ -290,6 +290,13 @@ def _create_argument_parser() -> ArgumentParser:
         ],
     )
     build.add_argument(
+        '--no-O2',
+        dest='o2',
+        default=None,
+        action='store_false',
+        help='Do not use optimization level 2.',
+    )
+    build.add_argument(
         '--regen',
         dest='regen',
         default=None,

--- a/src/kontrol/options.py
+++ b/src/kontrol/options.py
@@ -858,6 +858,7 @@ class BuildOptions(LoggingOptions, KOptions, KGenOptions, KompileOptions, Foundr
     @staticmethod
     def default() -> dict[str, Any]:
         return {
+            'o2': True,
             'regen': False,
             'rekompile': False,
             'forge_build': True,

--- a/src/kontrol/utils.py
+++ b/src/kontrol/utils.py
@@ -209,6 +209,7 @@ debug                      = false
 require                    = 'lemmas.k'
 module-import              = 'TestBase:KONTROL-LEMMAS'
 auxiliary-lemmas           = true
+o2                         = true
 
 [prove.default]
 foundry-project-root       = '.'


### PR DESCRIPTION
This PR enables `-O2` — optimization level 2 in LLVM backend — in `kontrol build` to avoid issues manifesting in the `empty response received` errors on Macs. It also adds 
```
o2 = true
```
to the `kontrol.toml` file.

Additionally, this PR adds a `--no-O2` option so it can be turned off. The updated `kontrol build --help` looks as follows:
```
❯ kontrol build --help
options:
...
  -O0                   Optimization level 0.
  -O1                   Optimization level 1.
  -O2                   Optimization level 2.
  -O3                   Optimization level 3.
  --enable-search       Enable search mode on LLVM backend krun.
  --coverage            Enable logging semantic rule coverage measurement.
  --gen-bison-parser    Generate standalone Bison parser for program sort.
  --gen-glr-bison-parser
                        Generate standalone GLR Bison parser for program sort.
  --bison-lists         Disable List{Sort} parsing to make grammar LR(1) for Bison parser.
...
  --no-O2               Do not use optimization level 2.
...
```

The values for `o2` and `no-o2` are also read correctly from `kontrol.toml` file.