### PR TITLE
improve the timeout to avoid the error caused by it.

### DIFF
--- a/.github/workflows/update-expected-output.yml
+++ b/.github/workflows/update-expected-output.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.ref != 'refs/heads/master'
     name: 'Update Kontrol expected output'
     runs-on: [self-hosted, linux, normal, fast]
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4

--- a/.github/workflows/update-expected-output.yml
+++ b/.github/workflows/update-expected-output.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.ref != 'refs/heads/master'
     name: 'Update Kontrol expected output'
     runs-on: [self-hosted, linux, normal, fast]
-    timeout-minutes: 120
+    timeout-minutes: 180
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4


### PR DESCRIPTION
Because 90 min is not enough to update the expetected files, we set it the same timeout as the test-pr.