### PR TITLE
Enable publishing a Docker image from a branch

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,7 +1,9 @@
 ---
 name: 'Push Docker Image'
 on:
-  workflow_dispatch:
+  pull_request:
+    branches:
+      - 'master'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -21,7 +23,8 @@ jobs:
         run: |
           KONTROL_VERSION=$(cat package/version)
           echo "CONTAINER_NAME=kontrol-ci-docker-${GITHUB_SHA}" >> ${GITHUB_ENV}
-          SANITIZED_BRANCH_NAME=${{ github.ref_name // '/' / '-' }}
+          # TODO:temp
+          SANITIZED_BRANCH_NAME=${{ github.head_ref // '/' / '-' }}
           TAG=runtimeverificationinc/kontrol:ubuntu-jammy-${SANITIZED_BRANCH_NAME}
           echo "TAG=${TAG}" >> ${GITHUB_ENV}
           echo "DOCKER_USER=user" >> ${GITHUB_ENV}

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -20,14 +20,14 @@ jobs:
       - name: 'Check out code'
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.events.inputs.kontrol_branch}}
+          ref: ${{ github.event.inputs.kontrol_branch}}
           fetch-depth: 0
 
       - name: 'Set environment'
         run: |
           KONTROL_VERSION=$(cat package/version)
           echo "CONTAINER_NAME=kontrol-ci-docker-${GITHUB_SHA}" >> ${GITHUB_ENV}
-          BRANCH_NAME="${{ github.events.inputs.kontrol_branch }}"
+          BRANCH_NAME="${{ github.event.inputs.kontrol_branch }}"
           SANITIZED_BRANCH_NAME=$(echo "${BRANCH_NAME}" | tr '/' '-' | tr -cd '[:alnum:]-_.')
           GHCR_TAG=ghcr.io/runtimeverification/kontrol/kontrol:ubuntu-jammy-${SANITIZED_BRANCH_NAME}
           echo "GHCR_TAG=${GHCR_TAG}" >> ${GITHUB_ENV}

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,9 +1,7 @@
 ---
 name: 'Push Docker Image'
 on:
-  pull_request:
-    branches:
-      - 'master'
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -23,8 +21,8 @@ jobs:
         run: |
           KONTROL_VERSION=$(cat package/version)
           echo "CONTAINER_NAME=kontrol-ci-docker-${GITHUB_SHA}" >> ${GITHUB_ENV}
-          # TODO:temp
-          SANITIZED_BRANCH_NAME=$(echo "${BRANCH_NAME}" | tr '/' '-')
+          BRANCH_NAME="${{ github.ref_name }}"
+          SANITIZED_BRANCH_NAME=$(echo "${BRANCH_NAME}" | tr '/' '-' | tr -cd '[:alnum:]-_.')
           TAG=runtimeverificationinc/kontrol:ubuntu-jammy-${SANITIZED_BRANCH_NAME}
           echo "TAG=${TAG}" >> ${GITHUB_ENV}
           echo "DOCKER_USER=user" >> ${GITHUB_ENV}

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,0 +1,69 @@
+---
+name: 'Push Docker Image'
+on:
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dockerhub:
+    name: 'Build and Publish Docker Image'
+    runs-on: [self-hosted, linux, normal]
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.push.head.sha }}
+          fetch-depth: 0
+
+      - name: 'Set environment'
+        run: |
+          KONTROL_VERSION=$(cat package/version)
+          TAG=runtimeverificationinc/kontrol:ubuntu-jammy-${{ github.ref_name }}
+          echo "TAG=${TAG}" >> ${GITHUB_ENV}
+
+      - name: 'Build Docker image'
+        run: |
+          K_VERSION=$(cat deps/k_release)
+          Z3_VERSION=$(cat deps/z3)
+          docker build . --no-cache --tag ${TAG} --build-arg K_VERSION=${K_VERSION} --build-arg Z3_VERSION=${Z3_VERSION}
+
+      - name: 'Run Docker image'
+        run: |
+          docker run                          \
+          --name ${CONTAINER_NAME}          \
+          --rm                              \
+          --interactive                     \
+          --tty                             \
+          --detach                          \
+          --user root                       \
+          ${TAG}
+
+          docker cp src/tests/integration/test-data/foundry ${CONTAINER_NAME}:${FOUNDRY_ROOT}
+          docker exec ${CONTAINER_NAME} chown -R ${DOCKER_USER}:${DOCKER_GROUP} ${FOUNDRY_ROOT}
+
+      - name: 'Run forge build'
+        run: |
+          docker exec --user ${DOCKER_USER} --workdir ${FOUNDRY_ROOT} ${CONTAINER_NAME} forge install --no-git foundry-rs/forge-std@75f1746
+          docker exec --user ${DOCKER_USER} --workdir ${FOUNDRY_ROOT} ${CONTAINER_NAME} forge install --no-git runtimeverification/kontrol-cheatcodes@a5dd4b0
+          docker exec --user ${DOCKER_USER} --workdir ${FOUNDRY_ROOT} ${CONTAINER_NAME} forge build
+  
+      - name: 'Run kontrol build'
+        run: docker exec --user ${DOCKER_USER} --workdir ${FOUNDRY_ROOT} ${CONTAINER_NAME} kontrol build -O2
+  
+      - name: 'Run kontrol prove'
+        run: docker exec --user ${DOCKER_USER} --workdir ${FOUNDRY_ROOT} ${CONTAINER_NAME} kontrol prove --match-test 'AssertTest.test_assert_true()'
+  
+      - name: 'Run kontrol show'
+        run: docker exec --user ${DOCKER_USER} --workdir ${FOUNDRY_ROOT} ${CONTAINER_NAME} kontrol show 'AssertTest.test_assert_true()'
+  
+      - name: 'Tear Down Docker'
+        if: always()
+        run: |
+          docker stop --time=0 ${CONTAINER_NAME}
+
+      - name: 'Push Docker Image to Docker Hub'
+        run: |
+          echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login --username rvdockerhub --password-stdin
+          docker image push ${TAG}

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,11 +1,7 @@
 ---
 name: 'Push Docker Image'
 on:
-  # workflow_dispatch:
-  # TODO: to be removed and substituted w/manual triggering, here for testing
-  pull_request:
-    branches:
-      - 'master'
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -26,7 +22,7 @@ jobs:
           KONTROL_VERSION=$(cat package/version)
           echo "CONTAINER_NAME=kontrol-ci-docker-${GITHUB_SHA}" >> ${GITHUB_ENV}
           SANITIZED_BRANCH_NAME=${{ github.ref_name // '/' / '-' }}
-          TAG=runtimeverificationinc/kontrol:ubuntu-jammy-${{ github.ref_name }}
+          TAG=runtimeverificationinc/kontrol:ubuntu-jammy-${SANITIZED_BRANCH_NAME}
           echo "TAG=${TAG}" >> ${GITHUB_ENV}
           echo "DOCKER_USER=user" >> ${GITHUB_ENV}
           echo "DOCKER_GROUP=user" >> ${GITHUB_ENV}

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,7 +1,12 @@
 ---
 name: 'Push Docker Image'
 on:
-  workflow_dispatch:
+  # TODO: remove, only for testing; replace with
+  # workflow_dispatch:
+  push:
+    branches:
+      - '**' # Trigger on every branch
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -23,8 +28,8 @@ jobs:
           echo "CONTAINER_NAME=kontrol-ci-docker-${GITHUB_SHA}" >> ${GITHUB_ENV}
           BRANCH_NAME="${{ github.ref_name }}"
           SANITIZED_BRANCH_NAME=$(echo "${BRANCH_NAME}" | tr '/' '-' | tr -cd '[:alnum:]-_.')
-          TAG=runtimeverificationinc/kontrol:ubuntu-jammy-${SANITIZED_BRANCH_NAME}
-          echo "TAG=${TAG}" >> ${GITHUB_ENV}
+          GHCR_TAG=ghcr.io/runtimeverification/kontrol/kontrol:ubuntu-jammy-${SANITIZED_BRANCH_NAME}
+          echo "GHCR_TAG=${GHCR_TAG}" >> ${GITHUB_ENV}
           echo "DOCKER_USER=user" >> ${GITHUB_ENV}
           echo "DOCKER_GROUP=user" >> ${GITHUB_ENV}
           echo "FOUNDRY_ROOT=/home/user/foundry" >> ${GITHUB_ENV}
@@ -33,7 +38,7 @@ jobs:
         run: |
           K_VERSION=$(cat deps/k_release)
           Z3_VERSION=$(cat deps/z3)
-          docker build . --no-cache --tag ${TAG} --build-arg K_VERSION=${K_VERSION} --build-arg Z3_VERSION=${Z3_VERSION}
+          docker build . --no-cache --tag ${GHCR_TAG} --build-arg K_VERSION=${K_VERSION} --build-arg Z3_VERSION=${Z3_VERSION}
 
       - name: 'Run Docker image'
         run: |
@@ -44,7 +49,7 @@ jobs:
           --tty                             \
           --detach                          \
           --user root                       \
-          ${TAG}
+          ${GHCR_TAG}
 
           docker cp src/tests/integration/test-data/foundry ${CONTAINER_NAME}:${FOUNDRY_ROOT}
           docker exec ${CONTAINER_NAME} chown -R ${DOCKER_USER}:${DOCKER_GROUP} ${FOUNDRY_ROOT}
@@ -69,7 +74,10 @@ jobs:
         run: |
           docker stop --time=0 ${CONTAINER_NAME}
 
-      - name: 'Push Docker Image to Docker Hub'
+      - name: 'Push Docker Image to GitHub Packages'
         run: |
-          echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login --username rvdockerhub --password-stdin
-          docker image push ${TAG}
+          echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ vars.DOCKERHUB_USERNAME }} --password-stdin
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+          docker push ${GHCR_TAG}
+
+

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -24,9 +24,13 @@ jobs:
       - name: 'Set environment'
         run: |
           KONTROL_VERSION=$(cat package/version)
-          # TODO: change `head_ref` to `ref_name`
-          TAG=runtimeverificationinc/kontrol:ubuntu-jammy-${{ github.head_ref }}
+          echo "CONTAINER_NAME=kontrol-ci-docker-${GITHUB_SHA}" >> ${GITHUB_ENV}
+          SANITIZED_BRANCH_NAME=${{ github.ref_name // '/' / '-' }}
+          TAG=runtimeverificationinc/kontrol:ubuntu-jammy-${{ github.ref_name }}
           echo "TAG=${TAG}" >> ${GITHUB_ENV}
+          echo "DOCKER_USER=user" >> ${GITHUB_ENV}
+          echo "DOCKER_GROUP=user" >> ${GITHUB_ENV}
+          echo "FOUNDRY_ROOT=/home/user/foundry" >> ${GITHUB_ENV}
 
       - name: 'Build Docker image'
         run: |
@@ -36,7 +40,7 @@ jobs:
 
       - name: 'Run Docker image'
         run: |
-          docker run                          \
+          docker run                        \
           --name ${CONTAINER_NAME}          \
           --rm                              \
           --interactive                     \

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -24,7 +24,8 @@ jobs:
       - name: 'Set environment'
         run: |
           KONTROL_VERSION=$(cat package/version)
-          TAG=runtimeverificationinc/kontrol:ubuntu-jammy-${{ github.ref_name }}
+          # TODO: change `head_ref` to `ref_name`
+          TAG=runtimeverificationinc/kontrol:ubuntu-jammy-${{ github.head_ref }}
           echo "TAG=${TAG}" >> ${GITHUB_ENV}
 
       - name: 'Build Docker image'

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,7 +1,11 @@
 ---
 name: 'Push Docker Image'
 on:
-  workflow_dispatch:
+  # workflow_dispatch:
+  # TODO: to be removed and substituted w/manual triggering, here for testing
+  pull_request:
+    branches:
+      - 'master'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,11 +1,12 @@
 ---
 name: 'Push Docker Image'
 on:
-  # TODO: remove, only for testing; replace with
-  # workflow_dispatch:
-  push:
-    branches:
-      - '**' # Trigger on every branch
+  workflow_dispatch:
+
+    inputs:
+      kontrol_branch:
+        description: "Branch of Kontrol to use to build the Docker image"
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,14 +20,14 @@ jobs:
       - name: 'Check out code'
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.push.head.sha }}
+          ref: ${{ github.events.inputs.kontrol_branch}}
           fetch-depth: 0
 
       - name: 'Set environment'
         run: |
           KONTROL_VERSION=$(cat package/version)
           echo "CONTAINER_NAME=kontrol-ci-docker-${GITHUB_SHA}" >> ${GITHUB_ENV}
-          BRANCH_NAME="${{ github.ref_name }}"
+          BRANCH_NAME="${{ github.events.inputs.kontrol_branch }}"
           SANITIZED_BRANCH_NAME=$(echo "${BRANCH_NAME}" | tr '/' '-' | tr -cd '[:alnum:]-_.')
           GHCR_TAG=ghcr.io/runtimeverification/kontrol/kontrol:ubuntu-jammy-${SANITIZED_BRANCH_NAME}
           echo "GHCR_TAG=${GHCR_TAG}" >> ${GITHUB_ENV}

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -24,7 +24,7 @@ jobs:
           KONTROL_VERSION=$(cat package/version)
           echo "CONTAINER_NAME=kontrol-ci-docker-${GITHUB_SHA}" >> ${GITHUB_ENV}
           # TODO:temp
-          SANITIZED_BRANCH_NAME=${{ github.head_ref // '/' / '-' }}
+          SANITIZED_BRANCH_NAME=$(echo "${BRANCH_NAME}" | tr '/' '-')
           TAG=runtimeverificationinc/kontrol:ubuntu-jammy-${SANITIZED_BRANCH_NAME}
           echo "TAG=${TAG}" >> ${GITHUB_ENV}
           echo "DOCKER_USER=user" >> ${GITHUB_ENV}


### PR DESCRIPTION
Related: https://github.com/runtimeverification/kaas/pull/996.

This PR adds a workflow that allows publishing kontrol image to ~Dockerhub~ ghrc.io, i.e., our GitHub org packages, from a specific branch. The image will be named `runtimeverification/kontrol:ubuntu-jammy-{branch_name}`.

Additionally, it sanitizes a branch name first: for example, github actions disallow the `/` symbol that appears in branch names — it gets replaced with `-`. 

Update: after a discussion with @yiyi-wang-rv, we decided to instead push the images to our private github packages, so they don't appear in our Dockerhub.
