### PR TITLE
Fix nested struct array rule generation

### DIFF
--- a/src/kontrol/solc_to_k.py
+++ b/src/kontrol/solc_to_k.py
@@ -213,7 +213,6 @@ class Input:
         else:
             return self.make_single_type()
 
-
     def flattened(self) -> list[Input]:
         components: list[Input] = []
 

--- a/src/kontrol/solc_to_k.py
+++ b/src/kontrol/solc_to_k.py
@@ -268,11 +268,10 @@ class Input:
         components: list[Input] = []
 
         if self.type.endswith('[]'):
-            base_type = self.type.rstrip('[]')
-
             if self.array_lengths is None:
                 raise ValueError(f'Array length bounds missing for {self.name}')
 
+            base_type = self.type.rstrip('[]')
             if base_type == 'tuple':
                 components = Input.process_tuple_array(self)
             else:

--- a/src/kontrol/solc_to_k.py
+++ b/src/kontrol/solc_to_k.py
@@ -213,56 +213,6 @@ class Input:
         else:
             return self.make_single_type()
 
-    def process_tuple_array(input: Input, index: int = 0) -> list['Input']:
-        """
-        Processes an input tuple array, appending `_index` to the names of components
-        and recursively handling nested tuples.
-        """
-        processed_components = []
-
-        if input.array_lengths is None:
-            raise ValueError(f'Array length bounds missing for {input.name}')
-
-        for i in range(input.array_lengths[0]):
-            for _c in input.components:
-                if _c.type == 'tuple':
-                    # Recursively process nested tuple components
-                    sub_components = tuple(Input.add_index_to_components(_c.components, i))
-                else:
-                    sub_components = _c.components
-
-                processed_component = Input(
-                    f'{_c.name}_{i}',
-                    _c.type,
-                    sub_components,
-                    _c.idx,
-                    array_lengths=_c.array_lengths,
-                    dynamic_type_length=_c.dynamic_type_length,
-                )
-                processed_components.append(processed_component)
-
-        return processed_components
-
-    @staticmethod
-    def add_index_to_components(components: tuple[Input, ...], index: int) -> list[Input]:
-        updated_components = []
-        for component in components:
-            if component.type == 'tuple':
-                # recursively add `_{i}` index to nested tuple components
-                updated_sub_components = tuple(Input.add_index_to_components(component.components, index))
-            else:
-                updated_sub_components = component.components
-            # Update the component's name and append to the result list
-            updated_component = Input(
-                f'{component.name}_{index}',
-                component.type,
-                updated_sub_components,
-                component.idx,
-                array_lengths=component.array_lengths,
-                dynamic_type_length=component.dynamic_type_length,
-            )
-            updated_components.append(updated_component)
-        return updated_components
 
     def flattened(self) -> list[Input]:
         components: list[Input] = []
@@ -991,6 +941,58 @@ class Contract:
                 res.append(next_char)
             i += 1
         return ''.join(res)
+
+    @staticmethod
+    def process_tuple_array(input: Input) -> list[Input]:
+        """
+        Processes an input tuple array, appending `_index` to the names of components
+        and recursively handling nested tuples.
+        """
+        processed_components = []
+
+        if input.array_lengths is None:
+            raise ValueError(f'Array length bounds missing for {input.name}')
+
+        for i in range(input.array_lengths[0]):
+            for _c in input.components:
+                if _c.type == 'tuple':
+                    # Recursively process nested tuple components
+                    sub_components = tuple(Input.add_index_to_components(_c.components, i))
+                else:
+                    sub_components = _c.components
+
+                processed_component = Input(
+                    f'{_c.name}_{i}',
+                    _c.type,
+                    sub_components,
+                    _c.idx,
+                    array_lengths=_c.array_lengths,
+                    dynamic_type_length=_c.dynamic_type_length,
+                )
+                processed_components.append(processed_component)
+
+        return processed_components
+
+    @staticmethod
+    def add_index_to_components(components: tuple[Input, ...], index: int) -> list[Input]:
+        updated_components = []
+        for component in components:
+            if component.type == 'tuple':
+                # recursively add `_{i}` index to nested tuple components
+                updated_sub_components = tuple(Input.add_index_to_components(component.components, index))
+            else:
+                updated_sub_components = component.components
+            # Update the component's name and append to the result list
+            updated_component = Input(
+                f'{component.name}_{index}',
+                component.type,
+                updated_sub_components,
+                component.idx,
+                array_lengths=component.array_lengths,
+                dynamic_type_length=component.dynamic_type_length,
+            )
+            updated_components.append(updated_component)
+        return updated_components
 
     @property
     def sort(self) -> KSort:

--- a/src/kontrol/solc_to_k.py
+++ b/src/kontrol/solc_to_k.py
@@ -213,9 +213,57 @@ class Input:
         else:
             return self.make_single_type()
 
+    def process_tuple_array(input: Input, index: int = 0) -> list['Input']:
+        """
+        Processes an input tuple array, appending `_index` to the names of components
+        and recursively handling nested tuples.
+        """
+        processed_components = []
+
+        for i in range(input.array_lengths[0]):
+            for _c in input.components:
+                if _c.type == 'tuple':
+                    # Recursively process nested tuple components
+                    sub_components = Input.add_index_to_components(_c.components, i)
+                else:
+                    sub_components = _c.components
+
+                processed_component = Input(
+                    f'{_c.name}_{i}',
+                    _c.type,
+                    sub_components,
+                    _c.idx,
+                    array_lengths=_c.array_lengths,
+                    dynamic_type_length=_c.dynamic_type_length,
+                )
+                processed_components.append(processed_component)
+
+        return processed_components
+
+    @staticmethod
+    def add_index_to_components(components: list[Input], index: int) -> list[Input]:
+        updated_components = []
+        for component in components:
+            if component.type == 'tuple':
+                # recursively add `_{i}` index to nested tuple components
+                updated_sub_components = Input.add_index_to_components(component.components, index)
+            else:
+                updated_sub_components = component.components
+            
+            # Update the component's name and append to the result list
+            updated_component = Input(
+                f'{component.name}_{index}',
+                component.type,
+                updated_sub_components,
+                component.idx,
+                array_lengths=component.array_lengths,
+                dynamic_type_length=component.dynamic_type_length,
+            )
+            updated_components.append(updated_component)
+        return updated_components
+
     def flattened(self) -> list[Input]:
         components = []
-        sub_components: tuple[Input, ...] = ()
 
         if self.type.endswith('[]'):
             if self.array_lengths is None:
@@ -223,33 +271,7 @@ class Input:
 
             base_type = self.type.rstrip('[]')
             if base_type == 'tuple':
-                for i in range(self.array_lengths[0]):
-                    for _c in self.components:
-                        # If this component is a tuple, append `_{i}` to its elements' names
-                        if _c.type == 'tuple':
-                            sub_components = tuple(
-                                Input(
-                                    f'{sub_component.name}_{i}',
-                                    sub_component.type,
-                                    sub_component.components,
-                                    sub_component.idx,
-                                    array_lengths=sub_component.array_lengths,
-                                    dynamic_type_length=sub_component.dynamic_type_length,
-                                )
-                                for sub_component in _c.components
-                            )
-                        else:
-                            sub_components = _c.components
-
-                        component = Input(
-                            f'{_c.name}_{i}',
-                            _c.type,
-                            sub_components,
-                            _c.idx,
-                            array_lengths=_c.array_lengths,
-                            dynamic_type_length=_c.dynamic_type_length,
-                        )
-                        components.append(component)
+                components = tuple(Input.process_tuple_array(self))
             else:
                 components = [Input(f'{self.name}_{i}', base_type, idx=self.idx) for i in range(self.array_lengths[0])]
         elif self.type == 'tuple':
@@ -439,35 +461,7 @@ class Contract:
                         if input.array_lengths is None:
                             raise ValueError(f'Array length bounds missing for {input.name}')
 
-                        tuple_array_components: list[Input] = []
-                        for i in range(input.array_lengths[0]):
-                            for _c in input.components:
-                                # If this component is a tuple, append `_{i}` to its elements' names
-                                if _c.type == 'tuple':
-                                    tuple_array_sub_components = tuple(
-                                        Input(
-                                            f'{sub_component.name}_{i}',
-                                            sub_component.type,
-                                            sub_component.components,
-                                            sub_component.idx,
-                                            array_lengths=sub_component.array_lengths,
-                                            dynamic_type_length=sub_component.dynamic_type_length,
-                                        )
-                                        for sub_component in _c.components
-                                    )
-                                else:
-                                    tuple_array_sub_components = _c.components
-
-                                tuple_array_component = Input(
-                                    f'{_c.name}_{i}',
-                                    _c.type,
-                                    tuple_array_sub_components,
-                                    _c.idx,
-                                    array_lengths=_c.array_lengths,
-                                    dynamic_type_length=_c.dynamic_type_length,
-                                )
-                                tuple_array_components.append(tuple_array_component)
-                        components = tuple(tuple_array_components)
+                    components = tuple(Input.process_tuple_array(input))
                     for sub_input in components:
                         _abi_type = sub_input.to_abi()
                         rps.extend(_range_predicates(_abi_type, sub_input.dynamic_type_length))
@@ -673,35 +667,7 @@ class Contract:
                         if input.array_lengths is None:
                             raise ValueError(f'Array length bounds missing for {input.name}')
 
-                        tuple_array_components: list[Input] = []
-                        for i in range(input.array_lengths[0]):
-                            for _c in input.components:
-                                # If this component is a tuple, append `_{i}` to its elements' names
-                                if _c.type == 'tuple':
-                                    tuple_array_sub_components = tuple(
-                                        Input(
-                                            f'{sub_component.name}_{i}',
-                                            sub_component.type,
-                                            sub_component.components,
-                                            sub_component.idx,
-                                            array_lengths=sub_component.array_lengths,
-                                            dynamic_type_length=sub_component.dynamic_type_length,
-                                        )
-                                        for sub_component in _c.components
-                                    )
-                                else:
-                                    tuple_array_sub_components = _c.components
-
-                                tuple_array_component = Input(
-                                    f'{_c.name}_{i}',
-                                    _c.type,
-                                    tuple_array_sub_components,
-                                    _c.idx,
-                                    array_lengths=_c.array_lengths,
-                                    dynamic_type_length=_c.dynamic_type_length,
-                                )
-                                tuple_array_components.append(tuple_array_component)
-                        components = tuple(tuple_array_components)
+                        components = tuple(Input.process_tuple_array(input))
 
                     for sub_input in components:
                         _abi_type = sub_input.to_abi()

--- a/src/tests/integration/test-data/foundry/test/NestedArrayStructs.t.sol
+++ b/src/tests/integration/test-data/foundry/test/NestedArrayStructs.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.13;
+
+import "forge-std/Test.sol";
+
+interface ProjectConfig {
+    struct ChainEnv {
+        string chainName;
+        string chainIndex;
+    }
+
+    struct Vault {
+        string tokenName;
+        address oracle;
+        uint256 allowedToTrade;
+        InputData params;
+        uint256 reserves;
+    }
+
+    struct InputData {
+        uint256 ltv;
+        uint256 rate;
+        uint256 exchangeRate;
+        uint256 utilization;
+    }
+
+    struct AssetAddresses {
+        address cToken;
+        address dToken;
+    }
+
+    struct VaultWithAddresses {
+        Vault vault;
+        AssetAddresses addresses;
+    }
+}
+
+contract NestedStructArrayTest is Test, ProjectConfig {
+    function testListAssetsCustom(ChainEnv calldata environment, VaultWithAddresses[] memory listings) external { 
+        assert(listings.length == 1);
+    }
+}

--- a/src/tests/integration/test-data/foundry/test/NestedArrayStructs.t.sol
+++ b/src/tests/integration/test-data/foundry/test/NestedArrayStructs.t.sol
@@ -36,7 +36,8 @@ interface ProjectConfig {
 }
 
 contract NestedStructArrayTest is Test, ProjectConfig {
-    function testListAssetsCustom(ChainEnv calldata environment, VaultWithAddresses[] memory listings) external { 
+    // this test branches on dynamically sized calldata and not run in CI; it is only meant to test `kontrol build`
+    function testVaultSignature(ChainEnv calldata environment, VaultWithAddresses[] memory listings) external { 
         assert(listings.length == 1);
     }
 }

--- a/src/tests/integration/test-data/show/contracts.k.expected
+++ b/src/tests/integration/test-data/show/contracts.k.expected
@@ -8801,6 +8801,124 @@ module S2KsrcZModMyToken-CONTRACT
 
 endmodule
 
+module S2KtestZModNestedStructArrayTest-CONTRACT
+    imports public FOUNDRY
+    
+    syntax Contract ::= S2KtestZModNestedStructArrayTestContract
+    
+    syntax S2KtestZModNestedStructArrayTestContract ::= "S2KtestZModNestedStructArrayTest" [symbol("contract_test%NestedStructArrayTest")]
+    
+    syntax Bytes ::= S2KtestZModNestedStructArrayTestContract "." S2KtestZModNestedStructArrayTestMethod [function, symbol("method_test%NestedStructArrayTest")]
+    
+    syntax S2KtestZModNestedStructArrayTestMethod ::= "S2KISZUndTEST" "(" ")" [symbol("method_test%NestedStructArrayTest_S2KISZUndTEST_")]
+    
+    syntax S2KtestZModNestedStructArrayTestMethod ::= "S2KexcludeArtifacts" "(" ")" [symbol("method_test%NestedStructArrayTest_S2KexcludeArtifacts_")]
+    
+    syntax S2KtestZModNestedStructArrayTestMethod ::= "S2KexcludeContracts" "(" ")" [symbol("method_test%NestedStructArrayTest_S2KexcludeContracts_")]
+    
+    syntax S2KtestZModNestedStructArrayTestMethod ::= "S2KexcludeSenders" "(" ")" [symbol("method_test%NestedStructArrayTest_S2KexcludeSenders_")]
+    
+    syntax S2KtestZModNestedStructArrayTestMethod ::= "S2Kfailed" "(" ")" [symbol("method_test%NestedStructArrayTest_S2Kfailed_")]
+    
+    syntax S2KtestZModNestedStructArrayTestMethod ::= "S2KtargetArtifactSelectors" "(" ")" [symbol("method_test%NestedStructArrayTest_S2KtargetArtifactSelectors_")]
+    
+    syntax S2KtestZModNestedStructArrayTestMethod ::= "S2KtargetArtifacts" "(" ")" [symbol("method_test%NestedStructArrayTest_S2KtargetArtifacts_")]
+    
+    syntax S2KtestZModNestedStructArrayTestMethod ::= "S2KtargetContracts" "(" ")" [symbol("method_test%NestedStructArrayTest_S2KtargetContracts_")]
+    
+    syntax S2KtestZModNestedStructArrayTestMethod ::= "S2KtargetSelectors" "(" ")" [symbol("method_test%NestedStructArrayTest_S2KtargetSelectors_")]
+    
+    syntax S2KtestZModNestedStructArrayTestMethod ::= "S2KtargetSenders" "(" ")" [symbol("method_test%NestedStructArrayTest_S2KtargetSenders_")]
+    
+    syntax S2KtestZModNestedStructArrayTestMethod ::= "S2KtestVaultSignature" "(" String ":" "string" "," String ":" "string" "," String ":" "string" "," Int ":" "address" "," Int ":" "uint256" "," Int ":" "uint256" "," Int ":" "uint256" "," Int ":" "uint256" "," Int ":" "uint256" "," Int ":" "uint256" "," Int ":" "address" "," Int ":" "address" ")" [symbol("method_test%NestedStructArrayTest_S2KtestVaultSignature_string_string_string_address_uint256_uint256_uint256_uint256_uint256_uint256_address_address")]
+    
+    rule  ( S2KtestZModNestedStructArrayTest . S2KISZUndTEST ( ) => #abiCallData ( "IS_TEST" , .TypedArgs ) )
+      
+    
+    rule  ( S2KtestZModNestedStructArrayTest . S2KexcludeArtifacts ( ) => #abiCallData ( "excludeArtifacts" , .TypedArgs ) )
+      
+    
+    rule  ( S2KtestZModNestedStructArrayTest . S2KexcludeContracts ( ) => #abiCallData ( "excludeContracts" , .TypedArgs ) )
+      
+    
+    rule  ( S2KtestZModNestedStructArrayTest . S2KexcludeSenders ( ) => #abiCallData ( "excludeSenders" , .TypedArgs ) )
+      
+    
+    rule  ( S2KtestZModNestedStructArrayTest . S2Kfailed ( ) => #abiCallData ( "failed" , .TypedArgs ) )
+      
+    
+    rule  ( S2KtestZModNestedStructArrayTest . S2KtargetArtifactSelectors ( ) => #abiCallData ( "targetArtifactSelectors" , .TypedArgs ) )
+      
+    
+    rule  ( S2KtestZModNestedStructArrayTest . S2KtargetArtifacts ( ) => #abiCallData ( "targetArtifacts" , .TypedArgs ) )
+      
+    
+    rule  ( S2KtestZModNestedStructArrayTest . S2KtargetContracts ( ) => #abiCallData ( "targetContracts" , .TypedArgs ) )
+      
+    
+    rule  ( S2KtestZModNestedStructArrayTest . S2KtargetSelectors ( ) => #abiCallData ( "targetSelectors" , .TypedArgs ) )
+      
+    
+    rule  ( S2KtestZModNestedStructArrayTest . S2KtargetSenders ( ) => #abiCallData ( "targetSenders" , .TypedArgs ) )
+      
+    
+    rule  ( S2KtestZModNestedStructArrayTest . S2KtestVaultSignature ( KV0_chainName : string , KV1_chainIndex : string , KV2_tokenName_0 : string , KV3_oracle_0 : address , KV4_allowedToTrade_0 : uint256 , KV5_ltv_0 : uint256 , KV6_rate_0 : uint256 , KV7_exchangeRate_0 : uint256 , KV8_utilization_0 : uint256 , KV6_reserves_0 : uint256 , KV3_cToken_0 : address , KV4_dToken_0 : address ) => #abiCallData ( "testVaultSignature" , ( #tuple ( ( #string ( KV0_chainName ) , ( #string ( KV1_chainIndex ) , .TypedArgs ) ) ) , ( #array ( #tuple ( ( #tuple ( ( #string ( KV2_tokenName_0 ) , ( #address ( KV3_oracle_0 ) , ( #uint256 ( KV4_allowedToTrade_0 ) , ( #tuple ( ( #uint256 ( KV5_ltv_0 ) , ( #uint256 ( KV6_rate_0 ) , ( #uint256 ( KV7_exchangeRate_0 ) , ( #uint256 ( KV8_utilization_0 ) , .TypedArgs ) ) ) ) ) , ( #uint256 ( KV6_reserves_0 ) , .TypedArgs ) ) ) ) ) ) , ( #tuple ( ( #address ( KV3_cToken_0 ) , ( #address ( KV4_dToken_0 ) , .TypedArgs ) ) ) , .TypedArgs ) ) ) , 1 , ( #tuple ( ( #tuple ( ( #string ( KV2_tokenName_0 ) , ( #address ( KV3_oracle_0 ) , ( #uint256 ( KV4_allowedToTrade_0 ) , ( #tuple ( ( #uint256 ( KV5_ltv_0 ) , ( #uint256 ( KV6_rate_0 ) , ( #uint256 ( KV7_exchangeRate_0 ) , ( #uint256 ( KV8_utilization_0 ) , .TypedArgs ) ) ) ) ) , ( #uint256 ( KV6_reserves_0 ) , .TypedArgs ) ) ) ) ) ) , ( #tuple ( ( #address ( KV3_cToken_0 ) , ( #address ( KV4_dToken_0 ) , .TypedArgs ) ) ) , .TypedArgs ) ) ) , .TypedArgs ) ) , .TypedArgs ) ) ) )
+       ensures ( #rangeAddress ( KV3_oracle_0 )
+       andBool ( #rangeUInt ( 256 , KV4_allowedToTrade_0 )
+       andBool ( #rangeUInt ( 256 , KV5_ltv_0 )
+       andBool ( #rangeUInt ( 256 , KV6_rate_0 )
+       andBool ( #rangeUInt ( 256 , KV7_exchangeRate_0 )
+       andBool ( #rangeUInt ( 256 , KV8_utilization_0 )
+       andBool ( #rangeUInt ( 256 , KV6_reserves_0 )
+       andBool ( #rangeAddress ( KV3_cToken_0 )
+       andBool ( #rangeAddress ( KV4_dToken_0 )
+               )))))))))
+      
+    
+    rule  ( selector ( "IS_TEST()" ) => 4202047188 )
+      
+    
+    rule  ( selector ( "excludeArtifacts()" ) => 3041954473 )
+      
+    
+    rule  ( selector ( "excludeContracts()" ) => 3792478065 )
+      
+    
+    rule  ( selector ( "excludeSenders()" ) => 517440284 )
+      
+    
+    rule  ( selector ( "failed()" ) => 3124842406 )
+      
+    
+    rule  ( selector ( "targetArtifactSelectors()" ) => 1725540768 )
+      
+    
+    rule  ( selector ( "targetArtifacts()" ) => 2233625729 )
+      
+    
+    rule  ( selector ( "targetContracts()" ) => 1064470260 )
+      
+    
+    rule  ( selector ( "targetSelectors()" ) => 2439649222 )
+      
+    
+    rule  ( selector ( "targetSenders()" ) => 1046363171 )
+      
+    
+    rule  ( selector ( "testVaultSignature((string,string),((string,address,uint256,(uint256,uint256,uint256,uint256),uint256),(address,address))[])" ) => 3906145641 )
+      
+
+endmodule
+
+module S2KtestZModProjectConfig-CONTRACT
+    imports public FOUNDRY
+    
+    syntax Contract ::= S2KtestZModProjectConfigContract
+    
+    syntax S2KtestZModProjectConfigContract ::= "S2KtestZModProjectConfig" [symbol("contract_test%ProjectConfig")]
+
+endmodule
+
 module S2KtestZModNestedStructsTest-CONTRACT
     imports public FOUNDRY
     

--- a/src/tests/integration/test-data/show/foundry.k.expected
+++ b/src/tests/integration/test-data/show/foundry.k.expected
@@ -109,6 +109,8 @@ module FOUNDRY-MAIN
     imports public S2KtestZModModelMockFunctionContract-VERIFICATION
     imports public S2KsrcZModMyIERC20-VERIFICATION
     imports public S2KsrcZModMyToken-VERIFICATION
+    imports public S2KtestZModNestedStructArrayTest-VERIFICATION
+    imports public S2KtestZModProjectConfig-VERIFICATION
     imports public S2KtestZModNestedStructsTest-VERIFICATION
     imports public S2KtestZModNoImport-VERIFICATION
     imports public S2KsrcZModcseZModUIntBinaryOp-VERIFICATION
@@ -886,6 +888,20 @@ endmodule
 
 module S2KsrcZModMyToken-VERIFICATION
     imports public S2KsrcZModMyToken-CONTRACT
+    
+    
+
+endmodule
+
+module S2KtestZModNestedStructArrayTest-VERIFICATION
+    imports public S2KtestZModNestedStructArrayTest-CONTRACT
+    
+    
+
+endmodule
+
+module S2KtestZModProjectConfig-VERIFICATION
+    imports public S2KtestZModProjectConfig-CONTRACT
     
     
 


### PR DESCRIPTION
Follow up to https://github.com/runtimeverification/kontrol/pull/830.

This PR ensures that the elements of nested structs up to an arbitrary depth all have `_{i}` indices appended to their names if they correspond to an array element.  It also factors out the processing of tuple array components into a separate function `process_tuple_array`.

This PR also adds a test that exercises the previously missing edge case, which manifested in variables on the LHS and in the `ensures` clause of the `#abiCalldata` rule in `contract.k` not having proper indexes (`..._0`) set.

 Please note that this test branches on the possible length of dynamically sized `strings` in the calldata, so it is meant to test `kontrol build` and is not run during the `kontrol prove` stage:

```solidity
// SPDX-License-Identifier: UNLICENSED
pragma solidity =0.8.13;

import "forge-std/Test.sol";

interface ProjectConfig {
    struct ChainEnv {
        string chainName;
        string chainIndex;
    }

    struct Vault {
        string tokenName;
        address oracle;
        uint256 allowedToTrade;
        InputData params;
        uint256 reserves;
    }

    struct InputData {
        uint256 ltv;
        uint256 rate;
        uint256 exchangeRate;
        uint256 utilization;
    }

    struct AssetAddresses {
        address cToken;
        address dToken;
    }

    struct VaultWithAddresses {
        Vault vault;
        AssetAddresses addresses;
    }
}

contract NestedStructArrayTest is Test, ProjectConfig {
    // this test branches on dynamically sized calldata and not run in CI; it is only meant to test `kontrol build`
    function testVaultSignature(ChainEnv calldata environment, VaultWithAddresses[] memory listings) external { 
        assert(listings.length == 1);
    }
}
```