### PR TITLE
Reorder `out/kompiled` directory creation and `forge build` in `kontrol build`

### DIFF
--- a/src/kontrol/kompile.py
+++ b/src/kontrol/kompile.py
@@ -38,9 +38,6 @@ def foundry_kompile(
     kompiled_timestamp = foundry.kompiled / 'timestamp'
     main_module = 'FOUNDRY-MAIN'
     includes = [Path(include) for include in options.includes if Path(include).exists()] + [KSRC_DIR]
-    ensure_dir_path(foundry.kompiled)
-    ensure_dir_path(foundry_requires_dir)
-
     requires_paths: dict[str, str] = {}
 
     if options.forge_build:
@@ -48,6 +45,9 @@ def foundry_kompile(
 
     if options.silence_warnings:
         options.ignore_warnings = _silenced_warnings()
+
+    ensure_dir_path(foundry.kompiled)
+    ensure_dir_path(foundry_requires_dir)
 
     regen = options.regen
     foundry_up_to_date = True


### PR DESCRIPTION
Closes https://github.com/runtimeverification/kontrol/issues/963.

This PR reorders the execution of `forge build` and creation of the `out/kompiled` folder, so that if `forge build` is ran with `--force`, it doesn't override the newly created `out/kompiled` folder.