### PR TITLE
Pin Foundry version in `nix` to the CI one

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -245,17 +245,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1740993113,
-        "narHash": "sha256-XY6CUZft7wjB/cbLyi/xeOZHh2mizSAT0EaYo9wuRXI=",
+        "lastModified": 1723453804,
+        "narHash": "sha256-u+4vfqBqYjYCyuEGYn8vNmRAs+R6MW3njRNKzzOAE0o=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "ed2a08376f14c0caf2b97418c91a66872e5ab3e2",
+        "rev": "221d7506a99f285ec6aee26245c55bbef8a407f1",
         "type": "github"
       },
       "original": {
         "owner": "shazow",
-        "ref": "monthly",
         "repo": "foundry.nix",
+        "rev": "221d7506a99f285ec6aee26245c55bbef8a407f1",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     poetry2nix.follows = "kevm/poetry2nix";
     foundry = {
       url =
-        "github:shazow/foundry.nix/monthly"; # Use monthly branch for permanent releases
+        "github:shazow/foundry.nix?rev=221d7506a99f285ec6aee26245c55bbef8a407f1"; # Use the same version as CI
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };


### PR DESCRIPTION
Fixes the issue identified by @jberthold where the Foundry version installed with `nix develop` is not compatible with some of the integration tests as a newer version changes the bytecode of contracts and lemmas are not getting applied. This PR pins the version in `flake.nix` to the one we use in CI.