### PR TITLE
Simplify generated module structure

### DIFF
--- a/src/kontrol/kompile.py
+++ b/src/kontrol/kompile.py
@@ -16,7 +16,6 @@ from pyk.utils import ensure_dir_path, hash_str
 
 from . import VERSION
 from .kdist.utils import KSRC_DIR
-from .solc_to_k import Contract, contract_to_main_module
 from .utils import _read_digest_file, _rv_blue, console, kontrol_up_to_date
 
 if TYPE_CHECKING:
@@ -171,23 +170,6 @@ def foundry_kompile(
 
     update_kompilation_digest()
     foundry.update_digest()
-
-
-def _foundry_to_contract_def(
-    contracts: Iterable[Contract],
-    requires: Iterable[str],
-    enums: dict[str, int],
-) -> KDefinition:
-    modules = [contract_to_main_module(contract, imports=['FOUNDRY']) for contract in contracts]
-    # First module is chosen as main module arbitrarily, since the contract definition is just a set of
-    # contract modules.
-    main_module = Contract.contract_to_module_name(list(contracts)[0].name_with_path)
-
-    return KDefinition(
-        main_module,
-        modules,
-        requires=(KRequire(req) for req in list(requires)),
-    )
 
 
 def _foundry_to_main_def(

--- a/src/kontrol/solc_to_k.py
+++ b/src/kontrol/solc_to_k.py
@@ -836,10 +836,6 @@ class Contract:
         return Contract.escaped(c, 'S2K') + '-CONTRACT'
 
     @staticmethod
-    def contract_to_verification_module_name(c: str) -> str:
-        return Contract.escaped(c, 'S2K') + '-VERIFICATION'
-
-    @staticmethod
     def escaped_chars() -> list[str]:
         return [Contract.PREFIX_CODE, '_', '$', '.', '-', '%', '@']
 
@@ -994,12 +990,6 @@ def solc_compile(contract_file: Path) -> dict[str, Any]:
 def contract_to_main_module(contract: Contract, imports: Iterable[str] = ()) -> KFlatModule:
     module_name = Contract.contract_to_module_name(contract.name_with_path)
     return KFlatModule(module_name, [], [KImport(i) for i in list(imports)])
-
-
-def contract_to_verification_module(contract: Contract, imports: Iterable[str]) -> KFlatModule:
-    main_module_name = Contract.contract_to_module_name(contract.name_with_path)
-    verification_module_name = Contract.contract_to_verification_module_name(contract.name_with_path)
-    return KFlatModule(verification_module_name, [], [KImport(main_module_name)] + [KImport(i) for i in list(imports)])
 
 
 # Helpers


### PR DESCRIPTION
Part of https://github.com/runtimeverification/kontrol/issues/977

Following https://github.com/runtimeverification/kontrol/pull/978, we don't need to generate any additional module structure because the generated modules in `contracts.k` are now just empty modules. Instead, we generate a flat module structure that includes the user-supplied lemmas directly into the main module and that's it.

In this PR:

- We no longer generate `contracts.k` file with the associated `KFlatModule` in them, instead the `foundry.k` imports the user-suppiled lemmas directly and the definition they supply directly.
- Output is updated accordingly.