### PR TITLE
Fix parsing lemmas-related `build` options in `kontrol.toml`

### DIFF
--- a/src/kontrol/options.py
+++ b/src/kontrol/options.py
@@ -846,6 +846,10 @@ class BuildOptions(LoggingOptions, KOptions, KompileOptions, FoundryOptions, Kom
             | KOptions.from_option_string()
             | KompileOptions.from_option_string()
             | KompileTargetOptions.from_option_string()
+            | {
+                'require': 'requires',
+                'module-import': 'imports',
+            }
         )
 
     @staticmethod
@@ -856,6 +860,10 @@ class BuildOptions(LoggingOptions, KOptions, KompileOptions, FoundryOptions, Kom
             | KOptions.get_argument_type()
             | KompileOptions.get_argument_type()
             | KompileTargetOptions.get_argument_type()
+            | {
+                'require': list_of(str),
+                'module-import': list_of(str),
+            }
         )
 
     def __str__(self) -> str:

--- a/src/tests/unit/test-data/kontrol_test.toml
+++ b/src/tests/unit/test-data/kontrol_test.toml
@@ -7,6 +7,8 @@ foundry-project-root    = '.'
 verbose                 = false
 debug                   = false
 optimization-level      = 3
+require                 = 'xor-lemmas.k'
+module-import           = 'TestBase:XOR-LEMMAS'
 
 [prove.b_profile]
 verbose                 = true

--- a/src/tests/unit/test_toml_args.py
+++ b/src/tests/unit/test_toml_args.py
@@ -82,6 +82,10 @@ def test_toml_specific_options() -> None:
     args_dict = parse_toml_args(args, get_option_string_destination, get_argument_type_setter)
     assert 'o3' in args_dict
     assert args_dict['o3']
+    assert 'requires' in args_dict
+    assert args_dict['requires'] == ['xor-lemmas.k']
+    assert 'imports' in args_dict
+    assert args_dict['imports'] == ['TestBase:XOR-LEMMAS']
 
 
 def test_toml_profiles() -> None:


### PR DESCRIPTION
Follow up to https://github.com/runtimeverification/kontrol/pull/979. 

This PR fixes parsing of `module-import = ...` and `require = ...` lemmas from `kontrol.toml` by mapping their names and types to those of the actual parameters' (`imports` and `requires`, respectively). Prior to https://github.com/runtimeverification/kontrol/pull/979, this was done when parsing `KGenOptions`, so that's something I missed during the review.

~TODO: add a test to `test_toml_args.py`.~