### PR TITLE
Make cachix builds from CI/CD match CLI/flake inputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,8 +34,7 @@
               ".github/"
               "result*"
               "/deps/"
-              # submodule directories are initilized empty by git, but
-              # not included by nix flakes/nix CLI
+              # do not include submodule directories that might be initilized empty or non-existent
               "/docs/external-computation"
             ] ./.
           );


### PR DESCRIPTION
This pull request fixes the same kind of issue that I already observed and fixed in `evm-semantics`, see [here](https://github.com/runtimeverification/evm-semantics/pull/2739). Now, I also observed this issue happening with `kontrol`. I will copy and paste the same explanation from the previous pull request in slightly adjusted form:

The CI/CD pipeline for `kontrol` releases builds and publishes kontrol to the [nix build cache k-framework-binary](https://app.cachix.org/cache/k-framework-binary). In the respective GitHub action job, the nix derivation is built by cloning the repository and building the derivation locally. Using git to clone causes empty submodule directories to be included in the source considered for the build. On the other hand, when the repository is referenced in a flake input or built by specifying a github URL in a nix CLI command, the empty submodule directories are omitted. This causes the package requested by CLI, specifically `kup`, or nix flake inputs to not match the package built by CI/CD that is pushed to the build cache. As a consequence, `kontrol` is built on the local machine instead of fetched from the binary cache.

This pull request fixes this mismatch by specifically not including the empty submodule directories in the final build.