### PR TITLE
Update nix in CI from 2.13.3 to 2.24.12

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -223,7 +223,7 @@ jobs:
         if: ${{ matrix.runner != 'MacM1' }}
         uses: cachix/install-nix-action@v22
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.12/install
           extra_nix_config: |
             substituters = http://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -42,7 +42,7 @@ jobs:
       - name: 'Install Nix/Cachix'
         uses: cachix/install-nix-action@v19
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.24.12/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - uses: cachix/cachix-action@v12


### PR DESCRIPTION
Currently our CI is installing nix version 2.13.3 from January 2023. On CI, nix runs into [a problem](https://github.com/runtimeverification/kontrol/actions/runs/14649357818/job/41111181365#step:9:15) when working with a flake input URL that starts with "file+https", as is used in this [flake](https://github.com/hellwolf/solc.nix/blob/6885b61bac89da19a6e3c70b89fdd592e2cef884/flake.nix#L9). Specifically, the problem occurs when CI runs `nix flake update`. This issue can be reproduced locally by running the same nix version as CI does:
```bash
nix shell github:NixOS/nix/2.13.3#nix --command nix flake update
```

This pull request updates the version that is installed on CI jobs from 2.13.3 to 2.24.12 from July 2024, matching the local setup where the issue no longer occurs.