### PR TITLE
CI fix cachix installation

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -230,7 +230,7 @@ jobs:
 
       - name: 'Install Cachix'
         if: ${{ matrix.runner != 'MacM1' }}
-        uses: cachix/cachix-action@v12
+        uses: cachix/cachix-action@v16
         with:
           name: k-framework
 

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -221,7 +221,7 @@ jobs:
 
       - name: 'Install Nix'
         if: ${{ matrix.runner != 'MacM1' }}
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v31.2.0
         with:
           install_url: https://releases.nixos.org/nix/nix-2.24.12/install
           extra_nix_config: |

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -45,7 +45,7 @@ jobs:
           install_url: https://releases.nixos.org/nix/nix-2.24.12/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v16
         with:
           name: k-framework
           authToken: ${{ secrets.CACHIX_PUBLIC_TOKEN }}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -40,7 +40,7 @@ jobs:
           echo ${K_VERSION} > deps/k_release
           git add deps/k_release && git commit -m "deps/k_release: sync release file version ${K_VERSION}" || true
       - name: 'Install Nix/Cachix'
-        uses: cachix/install-nix-action@v19
+        uses: cachix/install-nix-action@v31.2.0
         with:
           install_url: https://releases.nixos.org/nix/nix-2.24.12/install
           extra_nix_config: |


### PR DESCRIPTION
Recently, due to updates in our nix infrastructure, CI started to [break](https://github.com/runtimeverification/kontrol/actions/runs/14649357818/job/41111181365#step:9:15) whose issues could be fixed by updating the version of nix from 2.13.3 to 2.24.12. This was done in this [pull request](https://github.com/runtimeverification/kontrol/pull/1016).

This caused CI to [break](https://github.com/runtimeverification/kontrol/actions/runs/14661491210/job/41146761693?pr=1008#step:8:12) yet again, as cachix was not successfully installed.

Nix changed the nix profile location in nix 2.14, whose change was incorporated in `install-nix-action` in [v20](https://github.com/cachix/install-nix-action/releases/tag/v20). Due to this I figured that updating `install-nix-action` might fix our issue. I also figured that updating `cachix-action` might be beneficial, considering upstream changes that break old revisions.