### PR TITLE
Refactors to simplify import structure

### DIFF
--- a/src/kontrol/__main__.py
+++ b/src/kontrol/__main__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 import sys
 from collections.abc import Iterable
@@ -39,7 +38,6 @@ from .hevm import Hevm
 from .kompile import foundry_kompile
 from .prove import foundry_prove
 from .solc import CompilationUnit
-from .solc_to_k import solc_compile
 from .utils import _LOG_FORMAT, _rv_blue, _rv_yellow, check_k_version, config_file_path, console, loglevel
 
 if TYPE_CHECKING:
@@ -52,7 +50,6 @@ if TYPE_CHECKING:
     from .options import (
         BuildOptions,
         CleanOptions,
-        CompileOptions,
         GetModelOptions,
         InitOptions,
         ListOptions,
@@ -140,11 +137,6 @@ def exec_load_state(options: LoadStateOptions) -> None:
 
 def exec_version(options: VersionOptions) -> None:
     print(f'Kontrol version: {VERSION}')
-
-
-def exec_compile(options: CompileOptions) -> None:
-    res = solc_compile(options.contract_file)
-    print(json.dumps(res))
 
 
 def exec_build(options: BuildOptions) -> None:

--- a/src/kontrol/__main__.py
+++ b/src/kontrol/__main__.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 from pyk.cli.pyk import parse_toml_args
 from pyk.cterm.symbolic import CTermSMTError
 from pyk.proof.reachability import APRFailureInfo, APRProof
-from pyk.proof.tui import APRProofViewer
 
 from . import VERSION
 from .cli import _create_argument_parser, generate_options, get_argument_type_setter, get_option_string_destination
@@ -19,7 +18,6 @@ from .foundry import (
     foundry_list,
     foundry_merge_nodes,
     foundry_minimize_proof,
-    foundry_node_printer,
     foundry_refute_node,
     foundry_remove_node,
     foundry_section_edge,
@@ -29,6 +27,7 @@ from .foundry import (
     foundry_state_load,
     foundry_step_node,
     foundry_unrefute_node,
+    foundry_view,
     init_project,
     read_recorded_state_diff,
     read_recorded_state_dump,
@@ -36,14 +35,12 @@ from .foundry import (
 from .hevm import Hevm
 from .kompile import foundry_kompile
 from .prove import foundry_prove
-from .solc import CompilationUnit
 from .utils import _LOG_FORMAT, _rv_blue, _rv_yellow, check_k_version, config_file_path, console, loglevel
 
 if TYPE_CHECKING:
     from pathlib import Path
     from typing import Final, TypeVar
 
-    from pyk.kcfg.tui import KCFGElem
     from pyk.utils import BugReport
 
     from .options import (
@@ -280,18 +277,7 @@ def exec_view_kcfg(options: ViewKcfgOptions) -> None:
     foundry = _load_foundry(
         options.foundry_root, use_hex_encoding=options.use_hex_encoding, add_enum_constraints=options.enum_constraints
     )
-    test_id = foundry.get_test_id(options.test, options.version)
-    contract_name, _ = test_id.split('.')
-    proof = foundry.get_apr_proof(test_id)
-
-    compilation_unit = CompilationUnit.load_build_info(foundry.build_info)
-
-    def _custom_view(elem: KCFGElem) -> Iterable[str]:
-        return foundry.custom_view(contract_name, elem, compilation_unit)
-
-    node_printer = foundry_node_printer(foundry, contract_name, proof)
-    viewer = APRProofViewer(proof, foundry.kevm, node_printer=node_printer, custom_view=_custom_view)
-    viewer.run()
+    foundry_view(foundry, options)
 
 
 def exec_minimize_proof(options: MinimizeProofOptions) -> None:

--- a/src/kontrol/__main__.py
+++ b/src/kontrol/__main__.py
@@ -28,7 +28,6 @@ from .foundry import (
     foundry_split_node,
     foundry_state_load,
     foundry_step_node,
-    foundry_to_dot,
     foundry_unrefute_node,
     init_project,
     read_recorded_state_diff,
@@ -64,7 +63,6 @@ if TYPE_CHECKING:
         SimplifyNodeOptions,
         SplitNodeOptions,
         StepNodeOptions,
-        ToDotOptions,
         UnrefuteNodeOptions,
         VersionOptions,
         ViewKcfgOptions,
@@ -271,13 +269,6 @@ def exec_split_node(options: SplitNodeOptions) -> None:
     )
 
     print(f'Node {options.node} has been split into {node_ids} on condition {options.branch_condition}.')
-
-
-def exec_to_dot(options: ToDotOptions) -> None:
-    foundry_to_dot(
-        foundry=_load_foundry(options.foundry_root, add_enum_constraints=options.enum_constraints),
-        options=options,
-    )
 
 
 def exec_list(options: ListOptions) -> None:

--- a/src/kontrol/__main__.py
+++ b/src/kontrol/__main__.py
@@ -32,7 +32,6 @@ from .foundry import (
     read_recorded_state_diff,
     read_recorded_state_dump,
 )
-from .hevm import Hevm
 from .kompile import foundry_kompile
 from .prove import foundry_prove
 from .utils import _LOG_FORMAT, _rv_blue, _rv_yellow, check_k_version, config_file_path, console, loglevel
@@ -215,7 +214,7 @@ def exec_prove(options: ProveOptions) -> None:
             if isinstance(proof, APRProof) and isinstance(proof.failure_info, APRFailureInfo):
                 failure_log = proof.failure_info
             if options.failure_info and failure_log is not None:
-                log = failure_log.print() + (Foundry.help_info() if not options.hevm else Hevm.help_info(proof.id))
+                log = failure_log.print() + Foundry.help_info(proof.id, options.hevm)
                 for line in log:
                     print(line)
             refuted_nodes = list(proof.node_refutations.keys())

--- a/src/kontrol/cli.py
+++ b/src/kontrol/cli.py
@@ -28,7 +28,6 @@ from .options import (
     SimplifyNodeOptions,
     SplitNodeOptions,
     StepNodeOptions,
-    ToDotOptions,
     UnrefuteNodeOptions,
     VersionOptions,
     ViewKcfgOptions,
@@ -55,7 +54,6 @@ def generate_options(args: dict[str, Any]) -> LoggingOptions:
         'refute-node': RefuteNodeOptions(args),
         'unrefute-node': UnrefuteNodeOptions(args),
         'split-node': SplitNodeOptions(args),
-        'to-dot': ToDotOptions(args),
         'list': ListOptions(args),
         'view-kcfg': ViewKcfgOptions(args),
         'remove-node': RemoveNodeOptions(args),
@@ -85,7 +83,6 @@ def get_option_string_destination(command: str, option_string: str) -> str:
         'refute-node': RefuteNodeOptions.from_option_string(),
         'unrefute-node': UnrefuteNodeOptions.from_option_string(),
         'split-node': SplitNodeOptions.from_option_string(),
-        'to-dot': ToDotOptions.from_option_string(),
         'list': ListOptions.from_option_string(),
         'view-kcfg': ViewKcfgOptions.from_option_string(),
         'remove-node': RemoveNodeOptions.from_option_string(),
@@ -113,7 +110,6 @@ def get_argument_type_setter(command: str, option_string: str) -> Callable[[str]
         'refute-node': RefuteNodeOptions.get_argument_type(),
         'unrefute-node': UnrefuteNodeOptions.get_argument_type(),
         'split-node': SplitNodeOptions.get_argument_type(),
-        'to-dot': ToDotOptions.get_argument_type(),
         'list': ListOptions.get_argument_type(),
         'view-kcfg': ViewKcfgOptions.get_argument_type(),
         'remove-node': RemoveNodeOptions.get_argument_type(),
@@ -636,17 +632,6 @@ def _create_argument_parser() -> ArgumentParser:
         default=None,
         action='store_true',
         help='Run KCFG minimization routine before displaying it.',
-    )
-
-    command_parser.add_parser(
-        'to-dot',
-        help='Dump the given CFG for the test as DOT for visualization.',
-        parents=[
-            kontrol_cli_args.foundry_test_args,
-            kontrol_cli_args.logging_args,
-            kontrol_cli_args.foundry_args,
-            config_args.config_args,
-        ],
     )
 
     command_parser.add_parser(

--- a/src/kontrol/cli.py
+++ b/src/kontrol/cli.py
@@ -14,6 +14,7 @@ from .options import (
     BuildOptions,
     CleanOptions,
     CompileOptions,
+    ConfigType,
     GetModelOptions,
     InitOptions,
     ListOptions,
@@ -33,7 +34,7 @@ from .options import (
     VersionOptions,
     ViewKcfgOptions,
 )
-from .prove import ConfigType, parse_test_version_tuple
+from .utils import parse_test_version_tuple
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/src/kontrol/cli.py
+++ b/src/kontrol/cli.py
@@ -13,7 +13,6 @@ from pyk.utils import ensure_dir_path
 from .options import (
     BuildOptions,
     CleanOptions,
-    CompileOptions,
     ConfigType,
     GetModelOptions,
     InitOptions,
@@ -50,7 +49,6 @@ def generate_options(args: dict[str, Any]) -> LoggingOptions:
     options = {
         'load-state': LoadStateOptions(args),
         'version': VersionOptions(args),
-        'compile': CompileOptions(args),
         'build': BuildOptions(args),
         'prove': ProveOptions(args),
         'show': ShowOptions(args),
@@ -81,7 +79,6 @@ def get_option_string_destination(command: str, option_string: str) -> str:
     options = {
         'load-state': LoadStateOptions.from_option_string(),
         'version': VersionOptions.from_option_string(),
-        'compile': CompileOptions.from_option_string(),
         'build': BuildOptions.from_option_string(),
         'prove': ProveOptions.from_option_string(),
         'show': ShowOptions.from_option_string(),
@@ -110,7 +107,6 @@ def get_argument_type_setter(command: str, option_string: str) -> Callable[[str]
     options = {
         'load-state': LoadStateOptions.get_argument_type(),
         'version': VersionOptions.get_argument_type(),
-        'compile': CompileOptions.get_argument_type(),
         'build': BuildOptions.get_argument_type(),
         'prove': ProveOptions.get_argument_type(),
         'show': ShowOptions.get_argument_type(),
@@ -249,9 +245,6 @@ def _create_argument_parser() -> ArgumentParser:
     command_parser = parser.add_subparsers(dest='command', required=True)
 
     command_parser.add_parser('version', help='Print out version of Kontrol command.')
-
-    solc_args = command_parser.add_parser('compile', help='Generate combined JSON with solc compilation results.')
-    solc_args.add_argument('contract_file', type=file_path, help='Path to contract file.')
 
     build = command_parser.add_parser(
         'build',

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -86,7 +86,6 @@ if TYPE_CHECKING:
         SimplifyNodeOptions,
         SplitNodeOptions,
         StepNodeOptions,
-        ToDotOptions,
         UnrefuteNodeOptions,
     )
 
@@ -1068,18 +1067,6 @@ def foundry_show(
                 kevm_sentences_file.write_text('\n'.join(line.rstrip() for line in defn_lines))
 
     return '\n'.join([line.rstrip() for line in res_lines])
-
-
-def foundry_to_dot(foundry: Foundry, options: ToDotOptions) -> None:
-    dump_dir = foundry.proofs_dir / 'dump'
-    test_id = foundry.get_test_id(options.test, options.version)
-    contract_name, _ = single(foundry.matching_tests([options.test])).split('.')
-    proof = foundry.get_apr_proof(test_id)
-
-    node_printer = foundry_node_printer(foundry, contract_name, proof)
-    proof_show = APRProofShow(foundry.kevm, node_printer=node_printer)
-
-    proof_show.dump(proof, dump_dir, dot=True)
 
 
 def foundry_list(foundry: Foundry) -> list[str]:

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -48,6 +48,7 @@ from pyk.proof.tui import APRProofViewer
 from pyk.utils import ensure_dir_path, hash_str, run_process_2, single, unique
 
 from . import VERSION
+from .hevm import Hevm
 from .solc import CompilationUnit
 from .solc_to_k import Contract, _contract_name_from_bytecode
 from .state_record import RecreateState, StateDiffEntry, StateDumpEntry
@@ -736,7 +737,9 @@ class Foundry:
         )
 
     @staticmethod
-    def help_info() -> list[str]:
+    def help_info(proof_id: str, hevm: bool) -> list[str]:
+        if hevm:
+            return Hevm.help_info(proof_id)
         res_lines: list[str] = []
         res_lines.append('')
         res_lines.append('See `foundry_success` predicate for more information:')
@@ -991,7 +994,7 @@ def foundry_show(
             extra_module=foundry.load_lemmas(options.lemmas),
         ) as kcfg_explore:
             res_lines += print_failure_info(proof, kcfg_explore, options.counterexample_info)
-            res_lines += Foundry.help_info()
+            res_lines += Foundry.help_info(proof.id, False)
 
     if options.to_kevm_claims or options.to_kevm_rules:
         _foundry_labels = [

--- a/src/kontrol/options.py
+++ b/src/kontrol/options.py
@@ -720,24 +720,6 @@ class StepNodeOptions(FoundryTestOptions, LoggingOptions, RpcOptions, BugReportO
         )
 
 
-class ToDotOptions(FoundryTestOptions, LoggingOptions, FoundryOptions):
-    @staticmethod
-    def from_option_string() -> dict[str, str]:
-        return (
-            FoundryOptions.from_option_string()
-            | LoggingOptions.from_option_string()
-            | FoundryTestOptions.from_option_string()
-        )
-
-    @staticmethod
-    def get_argument_type() -> dict[str, Callable]:
-        return (
-            FoundryOptions.get_argument_type()
-            | LoggingOptions.get_argument_type()
-            | FoundryTestOptions.get_argument_type()
-        )
-
-
 class UnrefuteNodeOptions(LoggingOptions, FoundryTestOptions, FoundryOptions):
     node: NodeIdLike
 

--- a/src/kontrol/options.py
+++ b/src/kontrol/options.py
@@ -119,20 +119,6 @@ class CleanOptions(FoundryOptions, LoggingOptions):
         return FoundryOptions.get_argument_type() | LoggingOptions.get_argument_type()
 
 
-class CompileOptions(LoggingOptions):
-    contract_file: Path
-
-    @staticmethod
-    def from_option_string() -> dict[str, str]:
-        return LoggingOptions.from_option_string()
-
-    @staticmethod
-    def get_argument_type() -> dict[str, Callable]:
-        return LoggingOptions.get_argument_type() | {
-            'contract_file': file_path,
-        }
-
-
 class FoundryTestOptions(Options):
     test: str
     version: int | None

--- a/src/kontrol/prove.py
+++ b/src/kontrol/prove.py
@@ -36,9 +36,9 @@ from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn, TimeElaps
 from .foundry import Foundry, KontrolSemantics, foundry_to_xml
 from .hevm import Hevm
 from .options import ConfigType, TraceOptions
-from .solc_to_k import Contract, hex_string_to_int
+from .solc_to_k import Contract
 from .state_record import StateDiffEntry, StateDumpEntry
-from .utils import console, parse_test_version_tuple
+from .utils import console, hex_string_to_int, parse_test_version_tuple
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/src/kontrol/solc_to_k.py
+++ b/src/kontrol/solc_to_k.py
@@ -1085,13 +1085,6 @@ def method_sig_from_abi(method_json: dict, is_library: bool = False) -> str:
     return f'{method_name}({method_args})'
 
 
-def hex_string_to_int(hex: str) -> int:
-    if hex.startswith('0x'):
-        return int(hex, 16)
-    else:
-        raise ValueError('Invalid hex format')
-
-
 def find_function_calls(node: dict, fields: tuple[StorageField, ...]) -> list[str]:
     """Recursive function that takes a method AST and a set of storage fields and returns all the functions that are called in the given method.
 

--- a/src/kontrol/state_record.py
+++ b/src/kontrol/state_record.py
@@ -3,7 +3,7 @@ from typing import NamedTuple
 
 from eth_utils import to_checksum_address
 
-from .solc_to_k import hex_string_to_int
+from .utils import hex_string_to_int
 
 
 class SlotUpdate(NamedTuple):

--- a/src/kontrol/utils.py
+++ b/src/kontrol/utils.py
@@ -115,6 +115,13 @@ def parse_test_version_tuple(value: str) -> tuple[str, int | None]:
         return (value, None)
 
 
+def hex_string_to_int(hex: str) -> int:
+    if hex.startswith('0x'):
+        return int(hex, 16)
+    else:
+        raise ValueError('Invalid hex format')
+
+
 def write_to_file(file_path: Path, content: str, grant_exec_permission: bool = False) -> None:
     """
     Writes the given content to a file specified by the file path with or without execution rights.


### PR DESCRIPTION
I'm using a tool called `pydeps` to analyze the import structure of Kontrol and understand where it can be simplified. This PR does so.

The original import graph looks like this:

![kontrol](https://github.com/user-attachments/assets/75362ed2-1323-458d-b01f-9e26a4ac0bbf)

This PR does the following:

- Move function `hex_string_to_int` from `solc_to_k` to `utils`, a more natural place for it.
- Adjusts some imports in `kontrol.cli` to go directly to the modules they're importing from, instead of through `kontrol.prove`.
- Removes the commands `kontrol compile` and `kontrol to-dot` (which I believe are unused), and the associated code with them.
- Factors out `foundry_view` command to be reused in `__main__` instead of having the code inline (removes some imports from `__main__`.
- Refactor the logic around `--hevm` to remove it from being imported directly into `__main__`.

The new import graph loosk like this (a bit flatter):

![kontrol](https://github.com/user-attachments/assets/e01ce440-be9a-4f04-ae4a-3bd8f7664f3c)

I was using the following command to compute the imports graph (using `pydeps`: https://pydeps.readthedocs.io/en/latest/):

```
% pydeps -o kontrol.png -T png --no-show --cluster --max-bacon 4 src/kontrol
```