### PR TITLE
Factor out Foundry modules

### DIFF
--- a/src/kontrol/__main__.py
+++ b/src/kontrol/__main__.py
@@ -24,15 +24,13 @@ from .foundry import (
     foundry_section_edge,
     foundry_simplify_node,
     foundry_split_node,
-    foundry_state_load,
     foundry_step_node,
     foundry_unrefute_node,
     init_project,
-    read_recorded_state_diff,
-    read_recorded_state_dump,
 )
 from .kompile import foundry_kompile
 from .prove import foundry_prove
+from .state_record import foundry_state_load, read_recorded_state_diff, read_recorded_state_dump
 from .utils import _LOG_FORMAT, _rv_blue, _rv_yellow, check_k_version, config_file_path, console, loglevel
 
 if TYPE_CHECKING:

--- a/src/kontrol/__main__.py
+++ b/src/kontrol/__main__.py
@@ -11,6 +11,7 @@ from pyk.proof.reachability import APRFailureInfo, APRProof
 
 from . import VERSION
 from .cli import _create_argument_parser, generate_options, get_argument_type_setter, get_option_string_destination
+from .display import foundry_show, foundry_view
 from .foundry import (
     Foundry,
     foundry_clean,
@@ -21,13 +22,11 @@ from .foundry import (
     foundry_refute_node,
     foundry_remove_node,
     foundry_section_edge,
-    foundry_show,
     foundry_simplify_node,
     foundry_split_node,
     foundry_state_load,
     foundry_step_node,
     foundry_unrefute_node,
-    foundry_view,
     init_project,
     read_recorded_state_diff,
     read_recorded_state_dump,

--- a/src/kontrol/__main__.py
+++ b/src/kontrol/__main__.py
@@ -122,10 +122,11 @@ def main() -> None:
 
 
 def exec_load_state(options: LoadStateOptions) -> None:
-    foundry_state_load(
-        options=options,
-        foundry=_load_foundry(options.foundry_root, add_enum_constraints=options.enum_constraints),
-    )
+    foundry = _load_foundry(options.foundry_root, add_enum_constraints=options.enum_constraints)
+    if options.output_dir_name is None:
+        options.output_dir_name = foundry.profile.get('test', '')
+    output_dir = foundry._root / options.output_dir_name
+    foundry_state_load(options=options, output_dir=output_dir)
 
 
 def exec_version(options: VersionOptions) -> None:

--- a/src/kontrol/display.py
+++ b/src/kontrol/display.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from kevm_pyk.kevm import KEVMNodePrinter
+from kevm_pyk.utils import legacy_explore, print_failure_info
+from pyk.cterm import CTerm
+from pyk.kast.inner import KApply, KToken, KVariable
+from pyk.kast.manip import collect, extract_lhs, flatten_label
+from pyk.kast.outer import KDefinition, KFlatModule, KImport, KRequire
+from pyk.kcfg import KCFG
+from pyk.kcfg.minimize import KCFGMinimizer
+from pyk.prelude.kint import INT
+from pyk.proof.reachability import APRProof
+from pyk.proof.show import APRProofNodePrinter, APRProofShow
+from pyk.proof.tui import APRProofViewer
+from pyk.utils import single, unique
+
+from .foundry import Foundry, KontrolSemantics
+from .solc import CompilationUnit
+from .solc_to_k import Contract
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Final
+
+    from pyk.kast.inner import KInner
+    from pyk.kcfg.show import NodePrinter
+    from pyk.kcfg.tui import KCFGElem
+
+    from .options import ShowOptions, ViewKcfgOptions
+
+_LOGGER: Final = logging.getLogger(__name__)
+
+
+class FoundryNodePrinter(KEVMNodePrinter):
+    foundry: Foundry
+    contract_name: str
+    omit_unstable_output: bool
+    compilation_unit: CompilationUnit
+
+    def __init__(self, foundry: Foundry, contract_name: str, omit_unstable_output: bool = False):
+        KEVMNodePrinter.__init__(self, foundry.kevm)
+        self.foundry = foundry
+        self.contract_name = contract_name
+        self.omit_unstable_output = omit_unstable_output
+        self.compilation_unit = CompilationUnit.load_build_info(foundry.build_info)
+
+    def print_node(self, kcfg: KCFG, node: KCFG.Node) -> list[str]:
+        ret_strs = super().print_node(kcfg, node)
+        _pc = node.cterm.try_cell('PC_CELL')
+        program_cell = node.cterm.try_cell('PROGRAM_CELL')
+
+        if type(_pc) is KToken and _pc.sort == INT:
+            if type(program_cell) is KToken:
+                try:
+                    bytecode = ast.literal_eval(program_cell.token)
+                    instruction = self.compilation_unit.get_instruction(bytecode, int(_pc.token))
+                    ast_node = instruction.node()
+                    start_line, _, end_line, _ = ast_node.source_range()
+                    ret_strs.append(f'src: {str(Path(ast_node.source.name))}:{start_line}:{end_line}')
+                except Exception:
+                    pass
+
+        calldata_cell = node.cterm.try_cell('CALLDATA_CELL')
+
+        if type(program_cell) is KToken:
+            selector_bytes = None
+            if type(calldata_cell) is KToken:
+                selector_bytes = ast.literal_eval(calldata_cell.token)
+                selector_bytes = selector_bytes[:4]
+            elif (
+                type(calldata_cell) is KApply and calldata_cell.label.name == '_+Bytes__BYTES-HOOKED_Bytes_Bytes_Bytes'
+            ):
+                first_bytes = flatten_label(label='_+Bytes__BYTES-HOOKED_Bytes_Bytes_Bytes', kast=calldata_cell)[0]
+                if type(first_bytes) is KToken:
+                    selector_bytes = ast.literal_eval(first_bytes.token)
+                    selector_bytes = selector_bytes[:4]
+
+            if selector_bytes is not None:
+                selector = int.from_bytes(selector_bytes, 'big')
+                current_contract_name = self.foundry.contract_name_from_bytecode(ast.literal_eval(program_cell.token))
+                for contract_name, contract_obj in self.foundry.contracts.items():
+                    if current_contract_name == contract_name:
+                        for method in contract_obj.methods:
+                            if method.id == selector:
+                                ret_strs.append(f'method: {method.qualified_name}')
+
+        return ret_strs
+
+
+class FoundryAPRNodePrinter(FoundryNodePrinter, APRProofNodePrinter):
+    def __init__(self, foundry: Foundry, contract_name: str, proof: APRProof, omit_unstable_output: bool = False):
+        FoundryNodePrinter.__init__(self, foundry, contract_name, omit_unstable_output=omit_unstable_output)
+        APRProofNodePrinter.__init__(self, proof, foundry.kevm)
+
+
+def foundry_node_printer(
+    foundry: Foundry, contract_name: str, proof: APRProof, omit_unstable_output: bool = False
+) -> NodePrinter:
+    if type(proof) is APRProof:
+        return FoundryAPRNodePrinter(foundry, contract_name, proof, omit_unstable_output=omit_unstable_output)
+    raise ValueError(f'Cannot build NodePrinter for proof type: {type(proof)}')
+
+
+def foundry_show(
+    foundry: Foundry,
+    options: ShowOptions,
+) -> str:
+    test_id = foundry.get_test_id(options.test, options.version)
+    contract_name, _ = single(foundry.matching_tests([options.test])).split('.')
+    proof = foundry.get_apr_proof(test_id)
+
+    nodes: Iterable[int | str] = options.nodes
+    if options.pending:
+        nodes = list(nodes) + [node.id for node in proof.pending]
+    if options.failing:
+        nodes = list(nodes) + [node.id for node in proof.failing]
+    nodes = unique(nodes)
+
+    unstable_cells = [
+        '<program>',
+        '<jumpDests>',
+        '<pc>',
+        '<gas>',
+        '<code>',
+    ]
+
+    node_printer = foundry_node_printer(
+        foundry, contract_name, proof, omit_unstable_output=options.omit_unstable_output
+    )
+    proof_show = APRProofShow(foundry.kevm, node_printer=node_printer)
+
+    if options.minimize_kcfg:
+        KCFGMinimizer(proof.kcfg).minimize()
+
+    res_lines = proof_show.show(
+        proof,
+        nodes=nodes,
+        node_deltas=options.node_deltas,
+        to_module=options.to_module,
+        minimize=options.minimize,
+        sort_collections=options.sort_collections,
+        omit_cells=(unstable_cells if options.omit_unstable_output else []),
+    )
+
+    start_server = options.port is None
+
+    if options.failure_info:
+        with legacy_explore(
+            foundry.kevm,
+            kcfg_semantics=KontrolSemantics(),
+            id=test_id,
+            smt_timeout=options.smt_timeout,
+            smt_retry_limit=options.smt_retry_limit,
+            start_server=start_server,
+            port=options.port,
+            extra_module=foundry.load_lemmas(options.lemmas),
+        ) as kcfg_explore:
+            res_lines += print_failure_info(proof, kcfg_explore, options.counterexample_info)
+            res_lines += Foundry.help_info(proof.id, False)
+
+    if options.to_kevm_claims or options.to_kevm_rules:
+        _foundry_labels = [
+            prod.klabel
+            for prod in foundry.kevm.definition.all_modules_dict['FOUNDRY-CHEAT-CODES'].productions
+            if prod.klabel is not None
+        ]
+
+        def _remove_foundry_config(_cterm: CTerm) -> CTerm:
+            kevm_config_pattern = KApply(
+                '<generatedTop>',
+                [
+                    KApply(
+                        '<foundry>',
+                        [
+                            KVariable('KEVM_CELL'),
+                            KVariable('STACKCHECKS_CELL'),
+                            KVariable('CHEATCODES_CELL'),
+                            KVariable('KEVMTRACING_CELL'),
+                        ],
+                    ),
+                    KVariable('GENERATEDCOUNTER_CELL'),
+                ],
+            )
+            kevm_config_match = kevm_config_pattern.match(_cterm.config)
+            if kevm_config_match is None:
+                _LOGGER.warning('Unable to match on <kevm> cell.')
+                return _cterm
+            return CTerm(kevm_config_match['KEVM_CELL'], _cterm.constraints)
+
+        def _contains_foundry_klabel(_kast: KInner) -> bool:
+            _contains = False
+
+            def _collect_klabel(_k: KInner) -> None:
+                nonlocal _contains
+                if type(_k) is KApply and _k.label.name in _foundry_labels:
+                    _contains = True
+
+            collect(_collect_klabel, _kast)
+            return _contains
+
+        for node in proof.kcfg.nodes:
+            proof.kcfg.let_node(node.id, cterm=_remove_foundry_config(node.cterm))
+
+        # Due to bug in KCFG.replace_node: https://github.com/runtimeverification/pyk/issues/686
+        proof.kcfg = KCFG.from_dict(proof.kcfg.to_dict())
+
+        sentences = [
+            edge.to_rule(
+                'BASIC-BLOCK',
+                claim=(not options.to_kevm_rules),
+                defunc_with=foundry.kevm.definition,
+                minimize=options.minimize,
+            )
+            for edge in proof.kcfg.edges()
+        ]
+        sentences = [sent for sent in sentences if not _contains_foundry_klabel(sent.body)]
+        sentences = [
+            sent for sent in sentences if not KontrolSemantics().is_terminal(CTerm.from_kast(extract_lhs(sent.body)))
+        ]
+        if len(sentences) == 0:
+            _LOGGER.warning(f'No claims or rules retained for proof {proof.id}')
+
+        else:
+            module_name = Contract.escaped(proof.id.upper() + '-SPEC', '')
+            module = KFlatModule(module_name, sentences=sentences, imports=[KImport('VERIFICATION')])
+            defn = KDefinition(module_name, [module], requires=[KRequire('verification.k')])
+
+            defn_lines = foundry.kevm.pretty_print(defn, in_module='EVM').split('\n')
+
+            res_lines += defn_lines
+
+            if options.kevm_claim_dir is not None:
+                kevm_sentences_file = options.kevm_claim_dir / (module_name.lower() + '.k')
+                kevm_sentences_file.write_text('\n'.join(line.rstrip() for line in defn_lines))
+
+    return '\n'.join([line.rstrip() for line in res_lines])
+
+
+def foundry_view(foundry: Foundry, options: ViewKcfgOptions) -> None:
+    test_id = foundry.get_test_id(options.test, options.version)
+    contract_name, _ = test_id.split('.')
+    proof = foundry.get_apr_proof(test_id)
+
+    compilation_unit = CompilationUnit.load_build_info(foundry.build_info)
+
+    def _custom_view(elem: KCFGElem) -> Iterable[str]:
+        return foundry.custom_view(contract_name, elem, compilation_unit)
+
+    node_printer = foundry_node_printer(foundry, contract_name, proof)
+    viewer = APRProofViewer(proof, foundry.kevm, node_printer=node_printer, custom_view=_custom_view)
+    viewer.run()

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -1215,7 +1215,8 @@ def foundry_step_node(
             apr_proof.write_proof_data()
 
 
-def foundry_state_load(options: LoadStateOptions, foundry: Foundry) -> None:
+def foundry_state_load(options: LoadStateOptions, output_dir: Path) -> None:
+    ensure_dir_path(output_dir)
     accounts = read_contract_names(options.contract_names) if options.contract_names else {}
     recreate_state_contract = RecreateState(name=options.name, accounts=accounts)
     if options.from_state_diff:
@@ -1226,13 +1227,6 @@ def foundry_state_load(options: LoadStateOptions, foundry: Foundry) -> None:
         recorded_accounts = read_recorded_state_dump(options.accesses_file)
         for account in recorded_accounts:
             recreate_state_contract.extend_with_state_dump(account)
-
-    output_dir_name = options.output_dir_name
-    if output_dir_name is None:
-        output_dir_name = foundry.profile.get('test', '')
-
-    output_dir = foundry._root / output_dir_name
-    ensure_dir_path(output_dir)
 
     main_file = output_dir / Path(options.name + '.sol')
 

--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -16,24 +16,20 @@ from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 
 import tomlkit
-from kevm_pyk.kevm import KEVM, CustomStep, KEVMNodePrinter, KEVMSemantics
-from kevm_pyk.utils import legacy_explore, print_failure_info, print_model
+from kevm_pyk.kevm import KEVM, CustomStep, KEVMSemantics
+from kevm_pyk.utils import legacy_explore, print_model
 from pyk.cterm import CTerm
 from pyk.kast.inner import KApply, KInner, KSequence, KSort, KToken, KVariable, Subst
 from pyk.kast.manip import (
     cell_label_to_var_name,
-    collect,
-    extract_lhs,
-    flatten_label,
     free_vars,
     minimize_term,
     set_cell,
     top_down,
 )
-from pyk.kast.outer import KDefinition, KFlatModule, KImport, KRequire, KRule
+from pyk.kast.outer import KRule
 from pyk.kcfg import KCFG
 from pyk.kcfg.kcfg import Step
-from pyk.kcfg.minimize import KCFGMinimizer
 from pyk.kdist import kdist
 from pyk.prelude.bytes import bytesToken
 from pyk.prelude.collections import map_empty
@@ -43,12 +39,9 @@ from pyk.prelude.kint import INT, intToken
 from pyk.prelude.ml import mlEqualsFalse, mlEqualsTrue
 from pyk.proof.proof import Proof
 from pyk.proof.reachability import APRFailureInfo, APRProof
-from pyk.proof.show import APRProofNodePrinter, APRProofShow
-from pyk.proof.tui import APRProofViewer
 from pyk.utils import ensure_dir_path, hash_str, run_process_2, single, unique
 
 from . import VERSION
-from .solc import CompilationUnit
 from .solc_to_k import Contract, _contract_name_from_bytecode
 from .state_record import RecreateState, StateDiffEntry, StateDumpEntry
 from .utils import (
@@ -66,12 +59,11 @@ if TYPE_CHECKING:
     from typing import Any, Final
 
     from pyk.cterm import CTermSymbolic
-    from pyk.kast.outer import KAst
+    from pyk.kast.outer import KAst, KFlatModule
     from pyk.kcfg.kcfg import NodeIdLike
     from pyk.kcfg.semantics import KCFGExtendResult
     from pyk.kcfg.tui import KCFGElem
     from pyk.proof.implies import RefutationProof
-    from pyk.proof.show import NodePrinter
     from pyk.utils import BugReport
 
     from .options import (
@@ -83,13 +75,12 @@ if TYPE_CHECKING:
         RefuteNodeOptions,
         RemoveNodeOptions,
         SectionEdgeOptions,
-        ShowOptions,
         SimplifyNodeOptions,
         SplitNodeOptions,
         StepNodeOptions,
         UnrefuteNodeOptions,
-        ViewKcfgOptions,
     )
+    from .solc import CompilationUnit
 
 _LOGGER: Final = logging.getLogger(__name__)
 
@@ -959,156 +950,6 @@ class Foundry:
             shutil.rmtree(self.proofs_dir.absolute())
 
 
-def foundry_show(
-    foundry: Foundry,
-    options: ShowOptions,
-) -> str:
-    test_id = foundry.get_test_id(options.test, options.version)
-    contract_name, _ = single(foundry.matching_tests([options.test])).split('.')
-    proof = foundry.get_apr_proof(test_id)
-
-    nodes: Iterable[int | str] = options.nodes
-    if options.pending:
-        nodes = list(nodes) + [node.id for node in proof.pending]
-    if options.failing:
-        nodes = list(nodes) + [node.id for node in proof.failing]
-    nodes = unique(nodes)
-
-    unstable_cells = [
-        '<program>',
-        '<jumpDests>',
-        '<pc>',
-        '<gas>',
-        '<code>',
-    ]
-
-    node_printer = foundry_node_printer(
-        foundry, contract_name, proof, omit_unstable_output=options.omit_unstable_output
-    )
-    proof_show = APRProofShow(foundry.kevm, node_printer=node_printer)
-
-    if options.minimize_kcfg:
-        KCFGMinimizer(proof.kcfg).minimize()
-
-    res_lines = proof_show.show(
-        proof,
-        nodes=nodes,
-        node_deltas=options.node_deltas,
-        to_module=options.to_module,
-        minimize=options.minimize,
-        sort_collections=options.sort_collections,
-        omit_cells=(unstable_cells if options.omit_unstable_output else []),
-    )
-
-    start_server = options.port is None
-
-    if options.failure_info:
-        with legacy_explore(
-            foundry.kevm,
-            kcfg_semantics=KontrolSemantics(),
-            id=test_id,
-            smt_timeout=options.smt_timeout,
-            smt_retry_limit=options.smt_retry_limit,
-            start_server=start_server,
-            port=options.port,
-            extra_module=foundry.load_lemmas(options.lemmas),
-        ) as kcfg_explore:
-            res_lines += print_failure_info(proof, kcfg_explore, options.counterexample_info)
-            res_lines += Foundry.help_info(proof.id, False)
-
-    if options.to_kevm_claims or options.to_kevm_rules:
-        _foundry_labels = [
-            prod.klabel
-            for prod in foundry.kevm.definition.all_modules_dict['FOUNDRY-CHEAT-CODES'].productions
-            if prod.klabel is not None
-        ]
-
-        def _remove_foundry_config(_cterm: CTerm) -> CTerm:
-            kevm_config_pattern = KApply(
-                '<generatedTop>',
-                [
-                    KApply(
-                        '<foundry>',
-                        [
-                            KVariable('KEVM_CELL'),
-                            KVariable('STACKCHECKS_CELL'),
-                            KVariable('CHEATCODES_CELL'),
-                            KVariable('KEVMTRACING_CELL'),
-                        ],
-                    ),
-                    KVariable('GENERATEDCOUNTER_CELL'),
-                ],
-            )
-            kevm_config_match = kevm_config_pattern.match(_cterm.config)
-            if kevm_config_match is None:
-                _LOGGER.warning('Unable to match on <kevm> cell.')
-                return _cterm
-            return CTerm(kevm_config_match['KEVM_CELL'], _cterm.constraints)
-
-        def _contains_foundry_klabel(_kast: KInner) -> bool:
-            _contains = False
-
-            def _collect_klabel(_k: KInner) -> None:
-                nonlocal _contains
-                if type(_k) is KApply and _k.label.name in _foundry_labels:
-                    _contains = True
-
-            collect(_collect_klabel, _kast)
-            return _contains
-
-        for node in proof.kcfg.nodes:
-            proof.kcfg.let_node(node.id, cterm=_remove_foundry_config(node.cterm))
-
-        # Due to bug in KCFG.replace_node: https://github.com/runtimeverification/pyk/issues/686
-        proof.kcfg = KCFG.from_dict(proof.kcfg.to_dict())
-
-        sentences = [
-            edge.to_rule(
-                'BASIC-BLOCK',
-                claim=(not options.to_kevm_rules),
-                defunc_with=foundry.kevm.definition,
-                minimize=options.minimize,
-            )
-            for edge in proof.kcfg.edges()
-        ]
-        sentences = [sent for sent in sentences if not _contains_foundry_klabel(sent.body)]
-        sentences = [
-            sent for sent in sentences if not KontrolSemantics().is_terminal(CTerm.from_kast(extract_lhs(sent.body)))
-        ]
-        if len(sentences) == 0:
-            _LOGGER.warning(f'No claims or rules retained for proof {proof.id}')
-
-        else:
-            module_name = Contract.escaped(proof.id.upper() + '-SPEC', '')
-            module = KFlatModule(module_name, sentences=sentences, imports=[KImport('VERIFICATION')])
-            defn = KDefinition(module_name, [module], requires=[KRequire('verification.k')])
-
-            defn_lines = foundry.kevm.pretty_print(defn, in_module='EVM').split('\n')
-
-            res_lines += defn_lines
-
-            if options.kevm_claim_dir is not None:
-                kevm_sentences_file = options.kevm_claim_dir / (module_name.lower() + '.k')
-                kevm_sentences_file.write_text('\n'.join(line.rstrip() for line in defn_lines))
-
-    return '\n'.join([line.rstrip() for line in res_lines])
-
-
-def foundry_view(foundry: Foundry, options: ViewKcfgOptions) -> None:
-    test_id = foundry.get_test_id(options.test, options.version)
-    contract_name, _ = test_id.split('.')
-    proof = foundry.get_apr_proof(test_id)
-
-    compilation_unit = CompilationUnit.load_build_info(foundry.build_info)
-
-    def _custom_view(elem: KCFGElem) -> Iterable[str]:
-        return foundry.custom_view(contract_name, elem, compilation_unit)
-
-    node_printer = foundry_node_printer(foundry, contract_name, proof)
-    viewer = APRProofViewer(proof, foundry.kevm, node_printer=node_printer, custom_view=_custom_view)
-    viewer.run()
-
-
 def foundry_list(foundry: Foundry) -> list[str]:
     all_methods = [
         f'{contract.name_with_path}.{method.signature}'
@@ -1524,76 +1365,6 @@ def read_contract_names(contract_names: Path) -> dict[str, str]:
     if not contract_names.exists():
         raise FileNotFoundError(f'Contract names dictionary file not found: {contract_names}')
     return json.loads(contract_names.read_text())
-
-
-class FoundryNodePrinter(KEVMNodePrinter):
-    foundry: Foundry
-    contract_name: str
-    omit_unstable_output: bool
-    compilation_unit: CompilationUnit
-
-    def __init__(self, foundry: Foundry, contract_name: str, omit_unstable_output: bool = False):
-        KEVMNodePrinter.__init__(self, foundry.kevm)
-        self.foundry = foundry
-        self.contract_name = contract_name
-        self.omit_unstable_output = omit_unstable_output
-        self.compilation_unit = CompilationUnit.load_build_info(foundry.build_info)
-
-    def print_node(self, kcfg: KCFG, node: KCFG.Node) -> list[str]:
-        ret_strs = super().print_node(kcfg, node)
-        _pc = node.cterm.try_cell('PC_CELL')
-        program_cell = node.cterm.try_cell('PROGRAM_CELL')
-
-        if type(_pc) is KToken and _pc.sort == INT:
-            if type(program_cell) is KToken:
-                try:
-                    bytecode = ast.literal_eval(program_cell.token)
-                    instruction = self.compilation_unit.get_instruction(bytecode, int(_pc.token))
-                    ast_node = instruction.node()
-                    start_line, _, end_line, _ = ast_node.source_range()
-                    ret_strs.append(f'src: {str(Path(ast_node.source.name))}:{start_line}:{end_line}')
-                except Exception:
-                    pass
-
-        calldata_cell = node.cterm.try_cell('CALLDATA_CELL')
-
-        if type(program_cell) is KToken:
-            selector_bytes = None
-            if type(calldata_cell) is KToken:
-                selector_bytes = ast.literal_eval(calldata_cell.token)
-                selector_bytes = selector_bytes[:4]
-            elif (
-                type(calldata_cell) is KApply and calldata_cell.label.name == '_+Bytes__BYTES-HOOKED_Bytes_Bytes_Bytes'
-            ):
-                first_bytes = flatten_label(label='_+Bytes__BYTES-HOOKED_Bytes_Bytes_Bytes', kast=calldata_cell)[0]
-                if type(first_bytes) is KToken:
-                    selector_bytes = ast.literal_eval(first_bytes.token)
-                    selector_bytes = selector_bytes[:4]
-
-            if selector_bytes is not None:
-                selector = int.from_bytes(selector_bytes, 'big')
-                current_contract_name = self.foundry.contract_name_from_bytecode(ast.literal_eval(program_cell.token))
-                for contract_name, contract_obj in self.foundry.contracts.items():
-                    if current_contract_name == contract_name:
-                        for method in contract_obj.methods:
-                            if method.id == selector:
-                                ret_strs.append(f'method: {method.qualified_name}')
-
-        return ret_strs
-
-
-class FoundryAPRNodePrinter(FoundryNodePrinter, APRProofNodePrinter):
-    def __init__(self, foundry: Foundry, contract_name: str, proof: APRProof, omit_unstable_output: bool = False):
-        FoundryNodePrinter.__init__(self, foundry, contract_name, omit_unstable_output=omit_unstable_output)
-        APRProofNodePrinter.__init__(self, proof, foundry.kevm)
-
-
-def foundry_node_printer(
-    foundry: Foundry, contract_name: str, proof: APRProof, omit_unstable_output: bool = False
-) -> NodePrinter:
-    if type(proof) is APRProof:
-        return FoundryAPRNodePrinter(foundry, contract_name, proof, omit_unstable_output=omit_unstable_output)
-    raise ValueError(f'Cannot build NodePrinter for proof type: {type(proof)}')
 
 
 def init_project(project_root: Path, *, skip_forge: bool) -> None:

--- a/src/kontrol/state_record.py
+++ b/src/kontrol/state_record.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 from eth_utils import to_checksum_address
 from kevm_pyk.kevm import KEVM
@@ -15,6 +15,7 @@ from pyk.utils import ensure_dir_path
 from .utils import hex_string_to_int, read_contract_names
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from typing import TypeGuard
 
     from pyk.kast.inner import KApply

--- a/src/kontrol/utils.py
+++ b/src/kontrol/utils.py
@@ -107,6 +107,12 @@ def kontrol_up_to_date(digest_file: Path) -> bool:
     return digest_dict.get('kontrol', '') == VERSION
 
 
+def read_contract_names(contract_names: Path) -> dict[str, str]:
+    if not contract_names.exists():
+        raise FileNotFoundError(f'Contract names dictionary file not found: {contract_names}')
+    return json.loads(contract_names.read_text())
+
+
 def parse_test_version_tuple(value: str) -> tuple[str, int | None]:
     if ':' in value:
         test, version = value.split(':')

--- a/src/tests/integration/test_foundry_prove.py
+++ b/src/tests/integration/test_foundry_prove.py
@@ -801,7 +801,7 @@ def test_load_state_diff(
 
         foundry_root_dir = root_tmp_dir / 'foundry'
     foundry = Foundry(foundry_root=foundry_root_dir)
-
+    output_dir = foundry._root / foundry.profile.get('test', '')
     foundry_state_load(
         LoadStateOptions(
             {
@@ -811,7 +811,7 @@ def test_load_state_diff(
                 'from_state_diff': 'True',
             }
         ),
-        foundry=foundry,
+        output_dir=output_dir,
     )
 
     generated_main_file = foundry_root_dir / 'src' / 'LoadStateDiff.sol'
@@ -845,7 +845,7 @@ def test_load_state_dump(
 
         foundry_root_dir = root_tmp_dir / 'foundry'
     foundry = Foundry(foundry_root=foundry_root_dir)
-
+    output_dir = foundry._root / foundry.profile.get('test', '')
     foundry_state_load(
         LoadStateOptions(
             {
@@ -854,7 +854,7 @@ def test_load_state_dump(
                 'output_dir_name': 'src',
             }
         ),
-        foundry=foundry,
+        output_dir=output_dir,
     )
 
     generated_main_file = foundry_root_dir / 'src' / 'LoadStateDump.sol'

--- a/src/tests/integration/test_foundry_prove.py
+++ b/src/tests/integration/test_foundry_prove.py
@@ -18,7 +18,6 @@ from kontrol.foundry import (
     foundry_refute_node,
     foundry_remove_node,
     foundry_split_node,
-    foundry_state_load,
     foundry_step_node,
     foundry_unrefute_node,
 )
@@ -35,6 +34,7 @@ from kontrol.options import (
     UnrefuteNodeOptions,
 )
 from kontrol.prove import foundry_prove
+from kontrol.state_record import foundry_state_load
 
 from .utils import TEST_DATA_DIR, assert_fail, assert_or_update_show_output, assert_pass
 

--- a/src/tests/integration/test_foundry_prove.py
+++ b/src/tests/integration/test_foundry_prove.py
@@ -10,13 +10,13 @@ from pyk.proof import APRProof
 from pyk.proof.proof import Proof
 from pyk.utils import single
 
+from kontrol.display import foundry_show
 from kontrol.foundry import (
     Foundry,
     foundry_merge_nodes,
     foundry_minimize_proof,
     foundry_refute_node,
     foundry_remove_node,
-    foundry_show,
     foundry_split_node,
     foundry_state_load,
     foundry_step_node,

--- a/src/tests/integration/test_kontrol.py
+++ b/src/tests/integration/test_kontrol.py
@@ -11,7 +11,8 @@ from filelock import FileLock
 from pyk.kore.rpc import kore_server
 from pyk.utils import single
 
-from kontrol.foundry import Foundry, foundry_show, init_project
+from kontrol.display import foundry_show
+from kontrol.foundry import Foundry, init_project
 from kontrol.kompile import foundry_kompile
 from kontrol.options import BuildOptions, ProveOptions, ShowOptions
 from kontrol.prove import foundry_prove

--- a/src/tests/integration/test_kontrol_cse.py
+++ b/src/tests/integration/test_kontrol_cse.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from kontrol.foundry import foundry_show
+from kontrol.display import foundry_show
 from kontrol.options import ProveOptions, ShowOptions
 from kontrol.prove import ConfigType, foundry_prove
 

--- a/src/tests/integration/test_tracing.py
+++ b/src/tests/integration/test_tracing.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from kontrol.foundry import foundry_show
+from kontrol.display import foundry_show
 from kontrol.options import ProveOptions, ShowOptions, TraceOptions
 from kontrol.prove import foundry_prove
 

--- a/src/tests/unit/test_foundry_prove.py
+++ b/src/tests/unit/test_foundry_prove.py
@@ -6,8 +6,7 @@ import pytest
 from pyk.cterm import CTerm
 from pyk.kast.inner import KApply, KLabel, KSequence, KSort, KToken, KVariable
 
-from kontrol.prove import recorded_state_to_account_cells
-from kontrol.state_record import read_recorded_state_diff
+from kontrol.state_record import read_recorded_state_diff, recorded_state_to_account_cells
 from kontrol.utils import ensure_name_is_unique
 
 from .utils import TEST_DATA_DIR

--- a/src/tests/unit/test_foundry_prove.py
+++ b/src/tests/unit/test_foundry_prove.py
@@ -6,8 +6,8 @@ import pytest
 from pyk.cterm import CTerm
 from pyk.kast.inner import KApply, KLabel, KSequence, KSort, KToken, KVariable
 
-from kontrol.foundry import read_recorded_state_diff
 from kontrol.prove import recorded_state_to_account_cells
+from kontrol.state_record import read_recorded_state_diff
 from kontrol.utils import ensure_name_is_unique
 
 from .utils import TEST_DATA_DIR


### PR DESCRIPTION
~Blocked on: https://github.com/runtimeverification/kontrol/pull/1019~

This PR continues the refactoring in https://github.com/runtimeverification/kontrol/pull/1019 to factor out more of the module structure. In particular:

- A new module `kontrol.display` is factored out with the commands `foundry_show` and `foundry_view`, and all display-related helpers are moved there.
- Functionality related to processing state-diffs is lifted out of `prove.py` and directly into `__main__.py`, so that `state_record` no longer needs to be imported into `prove.py`.
- All the helpers, and the main command for state loading, are removed from `foundry.py` and moved to `state_record.py`.
- The function `Foundry.custom_view`, which did not really use much else from the Foundry class, is moved to `display` module.

In terms of import graph structure, we have that:

- `state_record` is no longer imported into `foundry.py`, only into `__main__.py`, so it's better isolated.
- `solc` is no longer imported into `foundry.py`, just into `display.py` where it's used.