### PR TITLE
Add GitHub workflow for updating pyproject-nix and uv

### DIFF
--- a/.github/workflows/update-pyproject-nix.yml
+++ b/.github/workflows/update-pyproject-nix.yml
@@ -1,0 +1,76 @@
+---
+name: 'Update pyproject-nix and uv'
+on:
+  workflow_dispatch:
+    inputs:
+      uv2nix-rev:
+        description: 'Commit revision to use for locking uv2nix.
+          Leave empty for an up-to-date commit.
+          See https://github.com/pyproject-nix/uv2nix'
+        required: false
+        type: string
+      pyproject-build-systems-rev:
+        description: 'Commit revision to use for locking pyproject-build-systems.
+          Leave empty for an up-to-date commit.
+          See https://github.com/pyproject-nix/build-system-pkgs'
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  update-pyproject-nix:
+    if: github.ref != 'refs/heads/master'
+    name: 'Update Kontrol nix input pyproject-nix'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.JENKINS_GITHUB_PAT }}
+      - name: 'Configure GitHub user'
+        run: |
+          git config user.name devops
+          git config user.email devops@runtimeverification.com
+      - name: 'Install Nix'
+        uses: cachix/install-nix-action@v31.2.0
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.24.12/install
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: 'Update uv2nix commit'
+        id: update-uv2nix-commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          UV2NIX_REV_UPSTREAM=$(gh api repos/pyproject-nix/uv2nix/commits/master --jq .sha)
+          UV2NIX_REV=${{ inputs.uv2nix-rev || '$UV2NIX_REV_UPSTREAM' }}
+          sed -i -r 's|(url = "github:pyproject-nix/uv2nix/)[a-zA-Z0-9]+(")|\1'$UV2NIX_REV'\2|' flake.nix
+          echo "uv2nix-rev="$UV2NIX_REV >> "$GITHUB_OUTPUT"
+      - name: 'Update pyproject-build-systems commit'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PYPROJ_BUILD_REV_UPSTREAM=$(gh api repos/pyproject-nix/build-system-pkgs/commits/master --jq .sha)
+          PYPROJ_BUILD_REV=${{ inputs.pyproject-build-systems-rev || '$PYPROJ_BUILD_REV_UPSTREAM' }}
+          sed -i -r 's|(url = "github:pyproject-nix/build-system-pkgs/)[a-zA-Z0-9]+(")|\1'$PYPROJ_BUILD_REV'\2|' flake.nix
+      - name: 'Update nix flake lock file'
+        run: |
+          nix flake lock
+      - name: 'Update uv version in GitHub workflows'
+        id: update-uv-workflows
+        run: |
+          UV_VERSION=$(curl https://raw.githubusercontent.com/pyproject-nix/uv2nix/${{ steps.update-uv2nix-commit.outputs.uv2nix-rev }}/pkgs/uv-bin/srcs.json | jq .version -r)
+          SED_COMMAND="/uses: astral-sh\/setup-uv@v[0-9.]+/{ n ; /with:/{ n ; s/version: .*/version: "$UV_VERSION"/ } }"
+          sed -i -r "$SED_COMMAND" .github/workflows/test-pr.yml
+          sed -i -r "$SED_COMMAND" .github/workflows/update-version.yml
+          echo "uv-version="$UV_VERSION >> "$GITHUB_OUTPUT"
+      - name: 'Create commit'
+        run: |
+          git add flake.nix flake.lock .github/workflows/test-pr.yml .github/workflows/update-version.yml && git commit -m "update pyproject-nix and uv to v${{ steps.update-uv-workflows.outputs.uv-version }}" || true
+      - name: 'Push commit'
+        run: |
+          git push


### PR DESCRIPTION
With the migration from `poetry` to `uv` and from `poetry2nix` to `uv2nix`, we have new tools that we want to keep updated. At the same time, we want these updates to happen explicitly and not silently with `nix flake update` invocations. Therefore, the respective `pyproject-nix` revisions are hard coded in the nix flake file. On top of that, due to verbosity, we decided to explicitly install `uv` with a [fixed version in CI](https://github.com/runtimeverification/kontrol/blob/2310dd7028c13a1b9d4d27593d99be329663af81/.github/workflows/test-pr.yml#L37).

To update `uv` and `uv2nix`, the revisions specified in the nix flake file `flake.nix` and the versions specified in the GitHub workflows must be updated and kept in sync. This pull request adds a dispatchable GitHub workflow that updates both and keeps the version always in sync.

By default, the workflow installs up-to-date master branch revisions of [`uv2nix`](https://github.com/pyproject-nix/uv2nix) and [`build-system-pkgs`](https://github.com/pyproject-nix/build-system-pkgs) from `pyproject-nix`. The `pyproject-nix` nix input is configured to follow the respective input in the `uv2nix` flake, which means that no revision must be explicitly configured. The version of `uv` that is used by `uv2nix` is specified in the `uv2nix` repository, see [here](https://github.com/pyproject-nix/uv2nix/blob/fe540e91c26f378c62bf6da365a97e848434d0cd/pkgs/uv-bin/srcs.json#L2). This version is automatically fetched and then updated in the GitHub workflows that install `uv` explicitly.