### PR TITLE
Re-introduce nix code that makes cachix builds from CI/CD match nix CLI/flake inputs after `uv2nix` migration

### DIFF
--- a/nix/kontrol-pyk/default.nix
+++ b/nix/kontrol-pyk/default.nix
@@ -19,7 +19,7 @@ let
   # patches cannot yet be applied to uv workspaces, so we use a derivation containing the src instead
   src = stdenvNoCC.mkDerivation {
     name = "kontrol-pyk-src";
-    src = ../../.;
+    src = callPackage ../kontrol-source { };
 
     dontConfigure = true;
     dontBuild = true;

--- a/nix/kontrol-source/default.nix
+++ b/nix/kontrol-source/default.nix
@@ -1,0 +1,14 @@
+{
+  lib,
+  nix-gitignore
+}:
+
+lib.cleanSource (nix-gitignore.gitignoreSourcePure [
+    ../../.gitignore
+    ".github/"
+    "result*"
+    "/deps/"
+    # do not include submodule directories that might be initilized empty or non-existent
+    "/docs/external-computation"
+  ] ../../.
+)

--- a/nix/kontrol/default.nix
+++ b/nix/kontrol/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation {
   ];
   nativeBuildInputs = [ makeWrapper ];
 
-  src = ../../.;
+  src = callPackage ../kontrol-source { };
 
   dontUseCmakeConfigure = true;
 


### PR DESCRIPTION
Pull request [runtimeverification/kontrol/pull/1013](https://github.com/runtimeverification/kontrol/pull/1013) introduced nix code that makes cachix builds from CI/CD match nix CLI/flake inputs. Without this change, `kup` built `kontrol` instead of fetching from the nix binary cache, as the requested version mismatched the version available in the cache due to a different nix hash. This pull request was validated working after merging, but the respective nix code got lost by a another nix pull request, the [`uv2nix` migration pull request](https://github.com/runtimeverification/kontrol/pull/1011).

This pull request re-introduces the respective nix code.