### PR TITLE
Remove second installation of nix and cachix in `update-version.yml` workflow

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -34,6 +34,11 @@ jobs:
           extra_nix_config: |
             substituters = http://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/cachix-action@v16
+        with:
+          name: k-framework
+          authToken: ${{ secrets.CACHIX_PUBLIC_TOKEN }}
       # note: we install uv from the nix flake in order to match the uv version that is used by uv2nix
       - name: 'Install uv'
         run: |
@@ -50,16 +55,6 @@ jobs:
           K_VERSION=$(uv run python3 -c 'import pyk; print(pyk.__version__)')
           echo ${K_VERSION} > deps/k_release
           git add deps/k_release && git commit -m "deps/k_release: sync release file version ${K_VERSION}" || true
-      - name: 'Install Nix/Cachix'
-        uses: cachix/install-nix-action@v31.2.0
-        with:
-          install_url: https://releases.nixos.org/nix/nix-2.24.12/install
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: cachix/cachix-action@v16
-        with:
-          name: k-framework
-          authToken: ${{ secrets.CACHIX_PUBLIC_TOKEN }}
       - name: 'Update Nix flake inputs'
         run: |
           KEVM_VERSION=$(cat deps/kevm_release)


### PR DESCRIPTION
Pull request #1028 changed CI workflows to install `uv` with nix in order to match the version of `uv` with the version that is used by `uv2nix`.  Due to this change, `nix` needs to be installed prior to installing `uv` in GitHub workflows.

This change broke the `update-version.yml` workflow, as nix and cachix were installed twice in the workflow. This is blocking respective update pull requests such as e.g. #1032 . This pull request fixes this issue by removing the second installation of nix and cachix.