### PR TITLE
Add git derivation to PATH of uv binary

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,8 +54,21 @@
     let
       # due to the nixpkgs that we use in this flake being outdated, uv is also heavily outdated
       # we can just use the binary release of uv provided by uv2nix
-      uvOverlay = final: prev: {
-        uv = uv2nix.packages.${final.system}.uv-bin;
+      uvOverlay = final: prev: 
+      let
+        uv-bin = uv2nix.packages.${final.system}.uv-bin;
+      in {
+        # haskell-backend uses kontrol for profiling and uses a nix develop shell with the `--ignore-environment` flag set
+        # uv has an optional runtime dependency on git, which is not included by default in the uv derivation
+        uv = final.symlinkJoin {
+          name = "uv";
+          paths = [ uv-bin ];
+          buildInputs = [ uv-bin final.makeWrapper ];
+          postBuild = ''
+            wrapProgram $out/bin/uv \
+              --prefix PATH : ${final.git}/bin
+          '';
+        };
       };
       kontrolOverlay = final: prev:
       let


### PR DESCRIPTION
The haskell-backend uses evm-semantics and kontrol for profiling. For this purpose, the script `scripts/performance-tests-kontrol.sh` runs the develop shell with the `--ignore-environment` for increased reproducibility. This in turn causes git to be missing from the environment, which is an optional runtime dependency for uv that is required for us, because we reference git repositories in the `pyproject.toml`.

This pull request wraps uv and adds the git derivation to the PATH of uv. This will make the `--ignore-environment` kontrol nix develop shell in haskell-backend work reproducibly.