### PR TITLE
Do not merge, tmp PR: checking lemmas that will be upstreamed in KEVM

### DIFF
--- a/src/kontrol/kdist/kontrol_lemmas.md
+++ b/src/kontrol/kdist/kontrol_lemmas.md
@@ -179,27 +179,9 @@ module KONTROL-AUX-LEMMAS
     // NEW LEMMAS
     //
 
-    rule [symb-program-index]:
-      M:Bytes [ N:Int ] => #asWord ( #range(M, N, 1) )
-      requires 0 <=Int N andBool N <Int lengthBytes(M)
-      [simplification(60), symbolic(M), concrete(N), preserves-definedness]
-
     rule X *Int Y <=Int Z => Y <Int ( Z +Int 1 ) /Int X
       requires 0 <Int X andBool 0 <=Int Z andBool ( Z +Int 1) modInt X ==Int 0
       [simplification, concrete(X, Z), preserves-definedness]
-
-    //
-    // List simplifications for `allowCalls`
-    //
-
-    // List membership check simplification for lists with a single element
-    rule KI:KItem in ListItem(KI:KItem) => true [simplification]
-    rule KI:KItem in ListItem(KJ:KItem) => KI ==K KJ [simplification]
-
-    // Recursive list membership check for lists with multiple elements
-    rule KI:KItem in (ListItem(KI) _REST) => true [simplification]
-    rule KI:KItem in (ListItem(KJ) REST) => KI in REST requires KI =/=K KJ [simplification]
-    rule _KI:KItem in .List => false [simplification]
 
 endmodule
 ```

--- a/src/tests/integration/test-data/symbolic-bytes-lemmas.k
+++ b/src/tests/integration/test-data/symbolic-bytes-lemmas.k
@@ -14,23 +14,6 @@ module SYMBOLIC-BYTES-LEMMAS
     rule b"" +Bytes B   => B [simplification]
 
     //
-    // Byte indexing in terms of #asWord
-    //
-    rule BA [ X ] => #asWord ( #range (BA, X, 1) )
-      requires X <=Int lengthBytes(BA)
-      [simplification(40)]
-
-    rule [bytes-concat-lookup-left]:
-        (A:Bytes +Bytes _:Bytes) [I] => A [I]
-      requires 0 <=Int I andBool I <Int lengthBytes(A)
-      [simplification, preserves-definedness]
-
-    rule [bytes-concat-lookup-right]:
-        (A:Bytes +Bytes B:Bytes) [I] => B [I -Int lengthBytes(A)]
-      requires lengthBytes(A) <=Int I
-      [simplification, preserves-definedness]
-
-    //
     // Equality of +Bytes
     //
     rule { B:Bytes #Equals B1:Bytes +Bytes B2:Bytes } =>


### PR DESCRIPTION
Checking if https://github.com/runtimeverification/evm-semantics/pull/2702 doesn't break Kontrol tests, trial removing of upstreamed lemmas from Kontrol aux files.