### PR TITLE
Set `run-constructor` to true in the default `kontrol.toml`

### DIFF
--- a/src/kontrol/utils.py
+++ b/src/kontrol/utils.py
@@ -263,7 +263,7 @@ break-on-calls             = false
 break-on-storage           = false
 break-on-basic-blocks      = false
 break-on-cheatcodes        = false
-run-constructor            = false
+run-constructor            = true
 no-stack-checks            = true
 
 [show.default]


### PR DESCRIPTION
Set `run-constructor` to true in the default `kontrol.toml` created by `kontrol init`. Since `run-constructor = false` also means that storage constants are not initialized, the previous configuration was likely to cause errors that would be difficulty to debug for new users who are not aware of this detail.