### PR TITLE
Add `heuristics=KontrolSemantics()` to `foundry_minimize_proof`

### DIFF
--- a/src/kontrol/foundry.py
+++ b/src/kontrol/foundry.py
@@ -1022,7 +1022,7 @@ def foundry_to_xml(foundry: Foundry, proofs: list[APRProof], report_name: str) -
 def foundry_minimize_proof(foundry: Foundry, options: MinimizeProofOptions) -> None:
     test_id = foundry.get_test_id(options.test, options.version)
     apr_proof = foundry.get_apr_proof(test_id)
-    apr_proof.minimize_kcfg(merge=options.merge)
+    apr_proof.minimize_kcfg(heuristics=KontrolSemantics(), merge=options.merge)
     apr_proof.write_proof_data()
 
 

--- a/src/tests/integration/test-data/show/minimized/MergeKCFGTest.test_branch_merge(uint256,uint256,bool).expected
+++ b/src/tests/integration/test-data/show/minimized/MergeKCFGTest.test_branch_merge(uint256,uint256,bool).expected
@@ -8,28 +8,30 @@
 │   method: test%MergeKCFGTest.setUp()
 │
 │  (1925 steps)
-├─ 17 (split)
+├─ 17
 │   k: JUMPI 99 bool2Word ( KV2_z:Int ==Int 0 ) ~> #pc [ JUMPI ] ~> #execute ~> #return ...
 │   pc: 85
 │   callDepth: 1
 │   statusCode: STATUSCODE:StatusCode
 │   src: test/nested/SimpleNested.t.sol:7:11
 │   method: src%Branches.applyOp(uint256,uint256,bool)
+│
+│  (668|741|460 steps)
+├─ 46 (split)
+│   k: #halt ~> CONTINUATION:K
+│   pc: 194
+│   callDepth: 0
+│   statusCode: EVMC_SUCCESS
+│   src: lib/forge-std/src/StdInvariant.sol:69:71
+│   method: test%MergeKCFGTest.test_branch_merge(uint256,uint256,bool)
 ┃
 ┃ (branch)
-┣━━┓ subst: .Subst
+┣━━┓ subst: ...
 ┃  ┃ constraint:
+┃  ┃     KV2_z:Int <Int 2
+┃  ┃     0 <=Int KV2_z:Int
 ┃  ┃     ( notBool KV2_z:Int ==Int 0 )
 ┃  │
-┃  ├─ 19
-┃  │   k: JUMPI 99 bool2Word ( KV2_z:Int ==Int 0 ) ~> #pc [ JUMPI ] ~> #execute ~> #return ...
-┃  │   pc: 85
-┃  │   callDepth: 1
-┃  │   statusCode: STATUSCODE:StatusCode
-┃  │   src: test/nested/SimpleNested.t.sol:7:11
-┃  │   method: src%Branches.applyOp(uint256,uint256,bool)
-┃  │
-┃  │  (668 steps)
 ┃  ├─ 39 (terminal)
 ┃  │   k: #halt ~> CONTINUATION:K
 ┃  │   pc: 194
@@ -46,20 +48,11 @@
 ┃      callDepth: CALLDEPTH_CELL_5d410f2a:Int
 ┃      statusCode: STATUSCODE_FINAL:StatusCode
 ┃
-┣━━┓ subst: .Subst
+┣━━┓ subst: ...
 ┃  ┃ constraint:
 ┃  ┃     KV2_z:Int ==Int 0
 ┃  ┃     ( KV0_x:Int ==Int 0 orBool KV1_y:Int <=Int maxUInt256 /Word KV0_x:Int )
 ┃  │
-┃  ├─ 44
-┃  │   k: JUMPI 99 bool2Word ( KV2_z:Int ==Int 0 ) ~> #pc [ JUMPI ] ~> #execute ~> #return ...
-┃  │   pc: 85
-┃  │   callDepth: 1
-┃  │   statusCode: STATUSCODE:StatusCode
-┃  │   src: test/nested/SimpleNested.t.sol:7:11
-┃  │   method: src%Branches.applyOp(uint256,uint256,bool)
-┃  │
-┃  │  (741 steps)
 ┃  ├─ 42 (terminal)
 ┃  │   k: #halt ~> CONTINUATION:K
 ┃  │   pc: 194
@@ -76,21 +69,12 @@
 ┃      callDepth: CALLDEPTH_CELL_5d410f2a:Int
 ┃      statusCode: STATUSCODE_FINAL:StatusCode
 ┃
-┗━━┓ subst: .Subst
+┗━━┓ subst: ...
    ┃ constraint:
    ┃     KV2_z:Int ==Int 0
    ┃     ( notBool KV0_x:Int ==Int 0 )
-   ┃     maxUInt256 /Word KV0_x:Int <Int KV1_y:Int
+   ┃     ( maxUInt256 /Int KV0_x:Int ) <Int KV1_y:Int
    │
-   ├─ 45
-   │   k: JUMPI 99 bool2Word ( KV2_z:Int ==Int 0 ) ~> #pc [ JUMPI ] ~> #execute ~> #return ...
-   │   pc: 85
-   │   callDepth: 1
-   │   statusCode: STATUSCODE:StatusCode
-   │   src: test/nested/SimpleNested.t.sol:7:11
-   │   method: src%Branches.applyOp(uint256,uint256,bool)
-   │
-   │  (460 steps)
    ├─ 43 (terminal)
    │   k: #halt ~> CONTINUATION:K
    │   pc: 194
@@ -107,6 +91,1148 @@
        callDepth: CALLDEPTH_CELL_5d410f2a:Int
        statusCode: STATUSCODE_FINAL:StatusCode
 
+
+┌─ 19 (root, leaf, pending)
+│   k: JUMPI 99 bool2Word ( KV2_z:Int ==Int 0 ) ~> #pc [ JUMPI ] ~> #execute ~> #return ...
+│   pc: 85
+│   callDepth: 1
+│   statusCode: STATUSCODE:StatusCode
+│   src: test/nested/SimpleNested.t.sol:7:11
+│   method: src%Branches.applyOp(uint256,uint256,bool)
+
+┌─ 44 (root, leaf, pending)
+│   k: JUMPI 99 bool2Word ( KV2_z:Int ==Int 0 ) ~> #pc [ JUMPI ] ~> #execute ~> #return ...
+│   pc: 85
+│   callDepth: 1
+│   statusCode: STATUSCODE:StatusCode
+│   src: test/nested/SimpleNested.t.sol:7:11
+│   method: src%Branches.applyOp(uint256,uint256,bool)
+
+┌─ 45 (root, leaf, pending)
+│   k: JUMPI 99 bool2Word ( KV2_z:Int ==Int 0 ) ~> #pc [ JUMPI ] ~> #execute ~> #return ...
+│   pc: 85
+│   callDepth: 1
+│   statusCode: STATUSCODE:StatusCode
+│   src: test/nested/SimpleNested.t.sol:7:11
+│   method: src%Branches.applyOp(uint256,uint256,bool)
+
+
+Node 19:
+
+( <generatedTop>
+  <foundry>
+    <kevm>
+      <k>
+        JUMPI 99 bool2Word ( KV2_z:Int ==Int 0 )
+        ~> #pc [ JUMPI ]
+        ~> #execute
+        ~> #return 128 32
+        ~> #pc [ CALL ]
+        ~> #execute
+        ~> CONTINUATION:K
+      </k>
+      <mode>
+        NORMAL
+      </mode>
+      <schedule>
+        CANCUN
+      </schedule>
+      <useGas>
+        false
+      </useGas>
+      <ethereum>
+        <evm>
+          <output>
+            b""
+          </output>
+          <callStack>
+            ListItem ( <callState>
+              <id>
+                #address ( FoundryTest )
+              </id>
+              <caller>
+                137122462167341575662000267002353578582749290296
+              </caller>
+              <callData>
+                b"\x15T\xa2\xa4" +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes #buf ( 32 , KV2_z:Int )
+              </callData>
+              <callValue>
+                0
+              </callValue>
+              <wordStack>
+                ( 228 : ( 3766377623 : ( 491460923342184218035706888008750043977755113263 : ( KV2_z:Int : ( KV1_y:Int : ( KV0_x:Int : ( 193 : ( 357868196 : .WordStack ) ) ) ) ) ) ) )
+              </wordStack>
+              <localMem>
+                b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xe0~\\\x97" +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes #buf ( 32 , KV2_z:Int )
+              </localMem>
+              <memoryUsed>
+                0
+              </memoryUsed>
+              <callGas>
+                0
+              </callGas>
+              <static>
+                false
+              </static>
+              <callDepth>
+                0
+              </callDepth>
+              <codeAddr>
+                #address ( FoundryTest )
+              </codeAddr>
+              ...
+            </callState> )
+          </callStack>
+          <interimStates>
+            ListItem ( { <accounts>
+              ( <account>
+                <acctID>
+                  #address ( FoundryCheat )
+                </acctID>
+                <balance>
+                  0
+                </balance>
+                <storage>
+                  .Map
+                </storage>
+                <origStorage>
+                  .Map
+                </origStorage>
+                <transientStorage>
+                  .Map
+                </transientStorage>
+                <nonce>
+                  0
+                </nonce>
+                ...
+              </account>
+              ( <account>
+                <acctID>
+                  #address ( FoundryTest )
+                </acctID>
+                <balance>
+                  maxUInt96
+                </balance>
+                <storage>
+                  ( 27 |-> 491460923342184218035706888008750043977755113263 )
+                </storage>
+                <origStorage>
+                  .Map
+                </origStorage>
+                <transientStorage>
+                  .Map
+                </transientStorage>
+                <nonce>
+                  2
+                </nonce>
+                ...
+              </account>
+              <account>
+                <acctID>
+                  491460923342184218035706888008750043977755113263
+                </acctID>
+                <balance>
+                  0
+                </balance>
+                <storage>
+                  .Map
+                </storage>
+                <origStorage>
+                  .Map
+                </origStorage>
+                <transientStorage>
+                  .Map
+                </transientStorage>
+                <nonce>
+                  1
+                </nonce>
+                ...
+              </account> ) )
+            </accounts> | <substate>
+              <selfDestruct>
+                SELFDESTRUCT_CELL:Set
+              </selfDestruct>
+              <log>
+                .List
+              </log>
+              <refund>
+                0
+              </refund>
+              <accessedAccounts>
+                ( SetItem ( #address ( FoundryCheat ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) )
+              </accessedAccounts>
+              <accessedStorage>
+                .Map
+              </accessedStorage>
+              <createdAccounts>
+                .Set
+              </createdAccounts>
+            </substate> } )
+          </interimStates>
+          <touchedAccounts>
+            ( SetItem ( #address ( FoundryTest ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) )
+          </touchedAccounts>
+          <callState>
+            <id>
+              491460923342184218035706888008750043977755113263
+            </id>
+            <caller>
+              #address ( FoundryTest )
+            </caller>
+            <callData>
+              b"\xe0~\\\x97" +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes #buf ( 32 , KV2_z:Int )
+            </callData>
+            <callValue>
+              0
+            </callValue>
+            <wordStack>
+              ( 0 : ( KV2_z:Int : ( KV1_y:Int : ( KV0_x:Int : ( 60 : ( 3766377623 : .WordStack ) ) ) ) ) )
+            </wordStack>
+            <localMem>
+              b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80"
+            </localMem>
+            <memoryUsed>
+              0
+            </memoryUsed>
+            <callGas>
+              0
+            </callGas>
+            <static>
+              false
+            </static>
+            <callDepth>
+              1
+            </callDepth>
+            <codeAddr>
+              491460923342184218035706888008750043977755113263
+            </codeAddr>
+            ...
+          </callState>
+          <substate>
+            <selfDestruct>
+              SELFDESTRUCT_CELL:Set
+            </selfDestruct>
+            <log>
+              .List
+            </log>
+            <refund>
+              0
+            </refund>
+            <accessedAccounts>
+              ( SetItem ( #address ( FoundryCheat ) ) ( SetItem ( #address ( FoundryTest ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) ) )
+            </accessedAccounts>
+            <accessedStorage>
+              .Map
+            </accessedStorage>
+            <createdAccounts>
+              .Set
+            </createdAccounts>
+          </substate>
+          <origin>
+            137122462167341575662000267002353578582749290296
+          </origin>
+          <block>
+            <number>
+              NUMBER_CELL:Int
+            </number>
+            <timestamp>
+              TIMESTAMP_CELL:Int
+            </timestamp>
+            ...
+          </block>
+          ...
+        </evm>
+        <network>
+          <chainID>
+            1
+          </chainID>
+          <accounts>
+            ( <account>
+              <acctID>
+                #address ( FoundryCheat )
+              </acctID>
+              <balance>
+                0
+              </balance>
+              <storage>
+                .Map
+              </storage>
+              <origStorage>
+                .Map
+              </origStorage>
+              <transientStorage>
+                .Map
+              </transientStorage>
+              <nonce>
+                0
+              </nonce>
+              ...
+            </account>
+            ( <account>
+              <acctID>
+                #address ( FoundryTest )
+              </acctID>
+              <balance>
+                maxUInt96
+              </balance>
+              <storage>
+                ( 27 |-> 491460923342184218035706888008750043977755113263 )
+              </storage>
+              <origStorage>
+                .Map
+              </origStorage>
+              <transientStorage>
+                .Map
+              </transientStorage>
+              <nonce>
+                2
+              </nonce>
+              ...
+            </account>
+            <account>
+              <acctID>
+                491460923342184218035706888008750043977755113263
+              </acctID>
+              <balance>
+                0
+              </balance>
+              <storage>
+                .Map
+              </storage>
+              <origStorage>
+                .Map
+              </origStorage>
+              <transientStorage>
+                .Map
+              </transientStorage>
+              <nonce>
+                1
+              </nonce>
+              ...
+            </account> ) )
+          </accounts>
+          ...
+        </network>
+      </ethereum>
+      ...
+    </kevm>
+    <stackChecks>
+      true
+    </stackChecks>
+    <cheatcodes>
+      <prank>
+        <active>
+          false
+        </active>
+        <singleCall>
+          false
+        </singleCall>
+        ...
+      </prank>
+      <expectedRevert>
+        <isRevertExpected>
+          false
+        </isRevertExpected>
+        ...
+      </expectedRevert>
+      <expectedOpcode>
+        <isOpcodeExpected>
+          false
+        </isOpcodeExpected>
+        ...
+      </expectedOpcode>
+      <expectEmit>
+        <recordEvent>
+          false
+        </recordEvent>
+        <isEventExpected>
+          false
+        </isEventExpected>
+        ...
+      </expectEmit>
+      <whitelist>
+        <isCallWhitelistActive>
+          false
+        </isCallWhitelistActive>
+        <allowedCallsList>
+          .List
+        </allowedCallsList>
+        <isStorageWhitelistActive>
+          false
+        </isStorageWhitelistActive>
+        <storageSlotList>
+          .List
+        </storageSlotList>
+      </whitelist>
+      <mockCalls>
+        .MockCallCellMap
+      </mockCalls>
+      <mockFunctions>
+        .MockFunctionCellMap
+      </mockFunctions>
+    </cheatcodes>
+  </foundry>
+  ...
+</generatedTop>
+#And ( #Not ( { KV2_z:Int #Equals 0 } )
+#And ( { true #Equals KV2_z:Int <Int 2 }
+#And ( { true #Equals 0 <=Int KV0_x:Int }
+#And ( { true #Equals 0 <=Int KV1_y:Int }
+#And ( { true #Equals 0 <=Int KV2_z:Int }
+#And ( { true #Equals pow24 <Int NUMBER_CELL:Int }
+#And ( { true #Equals NUMBER_CELL:Int <Int pow32 }
+#And ( { true #Equals 1073741824 <Int TIMESTAMP_CELL:Int }
+#And ( { true #Equals TIMESTAMP_CELL:Int <Int 34359738368 }
+#And ( { true #Equals KV0_x:Int <Int pow256 }
+#And ( { true #Equals KV1_y:Int <Int pow256 }
+#And { true #Equals KV0_x:Int <=Int ( maxUInt256 -Int KV1_y:Int ) } ) ) ) ) ) ) ) ) ) ) ) )
+
+
+
+Node 44:
+
+( <generatedTop>
+  <foundry>
+    <kevm>
+      <k>
+        JUMPI 99 bool2Word ( KV2_z:Int ==Int 0 )
+        ~> #pc [ JUMPI ]
+        ~> #execute
+        ~> #return 128 32
+        ~> #pc [ CALL ]
+        ~> #execute
+        ~> CONTINUATION:K
+      </k>
+      <mode>
+        NORMAL
+      </mode>
+      <schedule>
+        CANCUN
+      </schedule>
+      <useGas>
+        false
+      </useGas>
+      <ethereum>
+        <evm>
+          <output>
+            b""
+          </output>
+          <callStack>
+            ListItem ( <callState>
+              <id>
+                #address ( FoundryTest )
+              </id>
+              <caller>
+                137122462167341575662000267002353578582749290296
+              </caller>
+              <callData>
+                b"\x15T\xa2\xa4" +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes #buf ( 32 , KV2_z:Int )
+              </callData>
+              <callValue>
+                0
+              </callValue>
+              <wordStack>
+                ( 228 : ( 3766377623 : ( 491460923342184218035706888008750043977755113263 : ( KV2_z:Int : ( KV1_y:Int : ( KV0_x:Int : ( 193 : ( 357868196 : .WordStack ) ) ) ) ) ) ) )
+              </wordStack>
+              <localMem>
+                b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xe0~\\\x97" +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes #buf ( 32 , KV2_z:Int )
+              </localMem>
+              <memoryUsed>
+                0
+              </memoryUsed>
+              <callGas>
+                0
+              </callGas>
+              <static>
+                false
+              </static>
+              <callDepth>
+                0
+              </callDepth>
+              <codeAddr>
+                #address ( FoundryTest )
+              </codeAddr>
+              ...
+            </callState> )
+          </callStack>
+          <interimStates>
+            ListItem ( { <accounts>
+              ( <account>
+                <acctID>
+                  #address ( FoundryCheat )
+                </acctID>
+                <balance>
+                  0
+                </balance>
+                <storage>
+                  .Map
+                </storage>
+                <origStorage>
+                  .Map
+                </origStorage>
+                <transientStorage>
+                  .Map
+                </transientStorage>
+                <nonce>
+                  0
+                </nonce>
+                ...
+              </account>
+              ( <account>
+                <acctID>
+                  #address ( FoundryTest )
+                </acctID>
+                <balance>
+                  maxUInt96
+                </balance>
+                <storage>
+                  ( 27 |-> 491460923342184218035706888008750043977755113263 )
+                </storage>
+                <origStorage>
+                  .Map
+                </origStorage>
+                <transientStorage>
+                  .Map
+                </transientStorage>
+                <nonce>
+                  2
+                </nonce>
+                ...
+              </account>
+              <account>
+                <acctID>
+                  491460923342184218035706888008750043977755113263
+                </acctID>
+                <balance>
+                  0
+                </balance>
+                <storage>
+                  .Map
+                </storage>
+                <origStorage>
+                  .Map
+                </origStorage>
+                <transientStorage>
+                  .Map
+                </transientStorage>
+                <nonce>
+                  1
+                </nonce>
+                ...
+              </account> ) )
+            </accounts> | <substate>
+              <selfDestruct>
+                SELFDESTRUCT_CELL:Set
+              </selfDestruct>
+              <log>
+                .List
+              </log>
+              <refund>
+                0
+              </refund>
+              <accessedAccounts>
+                ( SetItem ( #address ( FoundryCheat ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) )
+              </accessedAccounts>
+              <accessedStorage>
+                .Map
+              </accessedStorage>
+              <createdAccounts>
+                .Set
+              </createdAccounts>
+            </substate> } )
+          </interimStates>
+          <touchedAccounts>
+            ( SetItem ( #address ( FoundryTest ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) )
+          </touchedAccounts>
+          <callState>
+            <id>
+              491460923342184218035706888008750043977755113263
+            </id>
+            <caller>
+              #address ( FoundryTest )
+            </caller>
+            <callData>
+              b"\xe0~\\\x97" +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes #buf ( 32 , KV2_z:Int )
+            </callData>
+            <callValue>
+              0
+            </callValue>
+            <wordStack>
+              ( 0 : ( KV2_z:Int : ( KV1_y:Int : ( KV0_x:Int : ( 60 : ( 3766377623 : .WordStack ) ) ) ) ) )
+            </wordStack>
+            <localMem>
+              b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80"
+            </localMem>
+            <memoryUsed>
+              0
+            </memoryUsed>
+            <callGas>
+              0
+            </callGas>
+            <static>
+              false
+            </static>
+            <callDepth>
+              1
+            </callDepth>
+            <codeAddr>
+              491460923342184218035706888008750043977755113263
+            </codeAddr>
+            ...
+          </callState>
+          <substate>
+            <selfDestruct>
+              SELFDESTRUCT_CELL:Set
+            </selfDestruct>
+            <log>
+              .List
+            </log>
+            <refund>
+              0
+            </refund>
+            <accessedAccounts>
+              ( SetItem ( #address ( FoundryCheat ) ) ( SetItem ( #address ( FoundryTest ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) ) )
+            </accessedAccounts>
+            <accessedStorage>
+              .Map
+            </accessedStorage>
+            <createdAccounts>
+              .Set
+            </createdAccounts>
+          </substate>
+          <origin>
+            137122462167341575662000267002353578582749290296
+          </origin>
+          <block>
+            <number>
+              NUMBER_CELL:Int
+            </number>
+            <timestamp>
+              TIMESTAMP_CELL:Int
+            </timestamp>
+            ...
+          </block>
+          ...
+        </evm>
+        <network>
+          <chainID>
+            1
+          </chainID>
+          <accounts>
+            ( <account>
+              <acctID>
+                #address ( FoundryCheat )
+              </acctID>
+              <balance>
+                0
+              </balance>
+              <storage>
+                .Map
+              </storage>
+              <origStorage>
+                .Map
+              </origStorage>
+              <transientStorage>
+                .Map
+              </transientStorage>
+              <nonce>
+                0
+              </nonce>
+              ...
+            </account>
+            ( <account>
+              <acctID>
+                #address ( FoundryTest )
+              </acctID>
+              <balance>
+                maxUInt96
+              </balance>
+              <storage>
+                ( 27 |-> 491460923342184218035706888008750043977755113263 )
+              </storage>
+              <origStorage>
+                .Map
+              </origStorage>
+              <transientStorage>
+                .Map
+              </transientStorage>
+              <nonce>
+                2
+              </nonce>
+              ...
+            </account>
+            <account>
+              <acctID>
+                491460923342184218035706888008750043977755113263
+              </acctID>
+              <balance>
+                0
+              </balance>
+              <storage>
+                .Map
+              </storage>
+              <origStorage>
+                .Map
+              </origStorage>
+              <transientStorage>
+                .Map
+              </transientStorage>
+              <nonce>
+                1
+              </nonce>
+              ...
+            </account> ) )
+          </accounts>
+          ...
+        </network>
+      </ethereum>
+      ...
+    </kevm>
+    <stackChecks>
+      true
+    </stackChecks>
+    <cheatcodes>
+      <prank>
+        <active>
+          false
+        </active>
+        <singleCall>
+          false
+        </singleCall>
+        ...
+      </prank>
+      <expectedRevert>
+        <isRevertExpected>
+          false
+        </isRevertExpected>
+        ...
+      </expectedRevert>
+      <expectedOpcode>
+        <isOpcodeExpected>
+          false
+        </isOpcodeExpected>
+        ...
+      </expectedOpcode>
+      <expectEmit>
+        <recordEvent>
+          false
+        </recordEvent>
+        <isEventExpected>
+          false
+        </isEventExpected>
+        ...
+      </expectEmit>
+      <whitelist>
+        <isCallWhitelistActive>
+          false
+        </isCallWhitelistActive>
+        <allowedCallsList>
+          .List
+        </allowedCallsList>
+        <isStorageWhitelistActive>
+          false
+        </isStorageWhitelistActive>
+        <storageSlotList>
+          .List
+        </storageSlotList>
+      </whitelist>
+      <mockCalls>
+        .MockCallCellMap
+      </mockCalls>
+      <mockFunctions>
+        .MockFunctionCellMap
+      </mockFunctions>
+    </cheatcodes>
+  </foundry>
+  ...
+</generatedTop>
+#And ( { KV2_z:Int #Equals 0 }
+#And ( { true #Equals KV2_z:Int <Int 2 }
+#And ( { true #Equals 0 <=Int KV0_x:Int }
+#And ( { true #Equals 0 <=Int KV1_y:Int }
+#And ( { true #Equals 0 <=Int KV2_z:Int }
+#And ( { true #Equals pow24 <Int NUMBER_CELL:Int }
+#And ( { true #Equals NUMBER_CELL:Int <Int pow32 }
+#And ( { true #Equals 1073741824 <Int TIMESTAMP_CELL:Int }
+#And ( { true #Equals TIMESTAMP_CELL:Int <Int 34359738368 }
+#And ( { true #Equals KV0_x:Int <Int pow256 }
+#And ( { true #Equals KV1_y:Int <Int pow256 }
+#And ( { true #Equals KV0_x:Int <=Int ( maxUInt256 -Int KV1_y:Int ) }
+#And { true #Equals ( KV0_x:Int ==Int 0 orBool KV1_y:Int <=Int maxUInt256 /Word KV0_x:Int ) } ) ) ) ) ) ) ) ) ) ) ) ) )
+
+
+
+Node 45:
+
+( <generatedTop>
+  <foundry>
+    <kevm>
+      <k>
+        JUMPI 99 bool2Word ( KV2_z:Int ==Int 0 )
+        ~> #pc [ JUMPI ]
+        ~> #execute
+        ~> #return 128 32
+        ~> #pc [ CALL ]
+        ~> #execute
+        ~> CONTINUATION:K
+      </k>
+      <mode>
+        NORMAL
+      </mode>
+      <schedule>
+        CANCUN
+      </schedule>
+      <useGas>
+        false
+      </useGas>
+      <ethereum>
+        <evm>
+          <output>
+            b""
+          </output>
+          <callStack>
+            ListItem ( <callState>
+              <id>
+                #address ( FoundryTest )
+              </id>
+              <caller>
+                137122462167341575662000267002353578582749290296
+              </caller>
+              <callData>
+                b"\x15T\xa2\xa4" +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes #buf ( 32 , KV2_z:Int )
+              </callData>
+              <callValue>
+                0
+              </callValue>
+              <wordStack>
+                ( 228 : ( 3766377623 : ( 491460923342184218035706888008750043977755113263 : ( KV2_z:Int : ( KV1_y:Int : ( KV0_x:Int : ( 193 : ( 357868196 : .WordStack ) ) ) ) ) ) ) )
+              </wordStack>
+              <localMem>
+                b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xe0~\\\x97" +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes #buf ( 32 , KV2_z:Int )
+              </localMem>
+              <memoryUsed>
+                0
+              </memoryUsed>
+              <callGas>
+                0
+              </callGas>
+              <static>
+                false
+              </static>
+              <callDepth>
+                0
+              </callDepth>
+              <codeAddr>
+                #address ( FoundryTest )
+              </codeAddr>
+              ...
+            </callState> )
+          </callStack>
+          <interimStates>
+            ListItem ( { <accounts>
+              ( <account>
+                <acctID>
+                  #address ( FoundryCheat )
+                </acctID>
+                <balance>
+                  0
+                </balance>
+                <storage>
+                  .Map
+                </storage>
+                <origStorage>
+                  .Map
+                </origStorage>
+                <transientStorage>
+                  .Map
+                </transientStorage>
+                <nonce>
+                  0
+                </nonce>
+                ...
+              </account>
+              ( <account>
+                <acctID>
+                  #address ( FoundryTest )
+                </acctID>
+                <balance>
+                  maxUInt96
+                </balance>
+                <storage>
+                  ( 27 |-> 491460923342184218035706888008750043977755113263 )
+                </storage>
+                <origStorage>
+                  .Map
+                </origStorage>
+                <transientStorage>
+                  .Map
+                </transientStorage>
+                <nonce>
+                  2
+                </nonce>
+                ...
+              </account>
+              <account>
+                <acctID>
+                  491460923342184218035706888008750043977755113263
+                </acctID>
+                <balance>
+                  0
+                </balance>
+                <storage>
+                  .Map
+                </storage>
+                <origStorage>
+                  .Map
+                </origStorage>
+                <transientStorage>
+                  .Map
+                </transientStorage>
+                <nonce>
+                  1
+                </nonce>
+                ...
+              </account> ) )
+            </accounts> | <substate>
+              <selfDestruct>
+                SELFDESTRUCT_CELL:Set
+              </selfDestruct>
+              <log>
+                .List
+              </log>
+              <refund>
+                0
+              </refund>
+              <accessedAccounts>
+                ( SetItem ( #address ( FoundryCheat ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) )
+              </accessedAccounts>
+              <accessedStorage>
+                .Map
+              </accessedStorage>
+              <createdAccounts>
+                .Set
+              </createdAccounts>
+            </substate> } )
+          </interimStates>
+          <touchedAccounts>
+            ( SetItem ( #address ( FoundryTest ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) )
+          </touchedAccounts>
+          <callState>
+            <id>
+              491460923342184218035706888008750043977755113263
+            </id>
+            <caller>
+              #address ( FoundryTest )
+            </caller>
+            <callData>
+              b"\xe0~\\\x97" +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes #buf ( 32 , KV2_z:Int )
+            </callData>
+            <callValue>
+              0
+            </callValue>
+            <wordStack>
+              ( 0 : ( KV2_z:Int : ( KV1_y:Int : ( KV0_x:Int : ( 60 : ( 3766377623 : .WordStack ) ) ) ) ) )
+            </wordStack>
+            <localMem>
+              b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80"
+            </localMem>
+            <memoryUsed>
+              0
+            </memoryUsed>
+            <callGas>
+              0
+            </callGas>
+            <static>
+              false
+            </static>
+            <callDepth>
+              1
+            </callDepth>
+            <codeAddr>
+              491460923342184218035706888008750043977755113263
+            </codeAddr>
+            ...
+          </callState>
+          <substate>
+            <selfDestruct>
+              SELFDESTRUCT_CELL:Set
+            </selfDestruct>
+            <log>
+              .List
+            </log>
+            <refund>
+              0
+            </refund>
+            <accessedAccounts>
+              ( SetItem ( #address ( FoundryCheat ) ) ( SetItem ( #address ( FoundryTest ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) ) )
+            </accessedAccounts>
+            <accessedStorage>
+              .Map
+            </accessedStorage>
+            <createdAccounts>
+              .Set
+            </createdAccounts>
+          </substate>
+          <origin>
+            137122462167341575662000267002353578582749290296
+          </origin>
+          <block>
+            <number>
+              NUMBER_CELL:Int
+            </number>
+            <timestamp>
+              TIMESTAMP_CELL:Int
+            </timestamp>
+            ...
+          </block>
+          ...
+        </evm>
+        <network>
+          <chainID>
+            1
+          </chainID>
+          <accounts>
+            ( <account>
+              <acctID>
+                #address ( FoundryCheat )
+              </acctID>
+              <balance>
+                0
+              </balance>
+              <storage>
+                .Map
+              </storage>
+              <origStorage>
+                .Map
+              </origStorage>
+              <transientStorage>
+                .Map
+              </transientStorage>
+              <nonce>
+                0
+              </nonce>
+              ...
+            </account>
+            ( <account>
+              <acctID>
+                #address ( FoundryTest )
+              </acctID>
+              <balance>
+                maxUInt96
+              </balance>
+              <storage>
+                ( 27 |-> 491460923342184218035706888008750043977755113263 )
+              </storage>
+              <origStorage>
+                .Map
+              </origStorage>
+              <transientStorage>
+                .Map
+              </transientStorage>
+              <nonce>
+                2
+              </nonce>
+              ...
+            </account>
+            <account>
+              <acctID>
+                491460923342184218035706888008750043977755113263
+              </acctID>
+              <balance>
+                0
+              </balance>
+              <storage>
+                .Map
+              </storage>
+              <origStorage>
+                .Map
+              </origStorage>
+              <transientStorage>
+                .Map
+              </transientStorage>
+              <nonce>
+                1
+              </nonce>
+              ...
+            </account> ) )
+          </accounts>
+          ...
+        </network>
+      </ethereum>
+      ...
+    </kevm>
+    <stackChecks>
+      true
+    </stackChecks>
+    <cheatcodes>
+      <prank>
+        <active>
+          false
+        </active>
+        <singleCall>
+          false
+        </singleCall>
+        ...
+      </prank>
+      <expectedRevert>
+        <isRevertExpected>
+          false
+        </isRevertExpected>
+        ...
+      </expectedRevert>
+      <expectedOpcode>
+        <isOpcodeExpected>
+          false
+        </isOpcodeExpected>
+        ...
+      </expectedOpcode>
+      <expectEmit>
+        <recordEvent>
+          false
+        </recordEvent>
+        <isEventExpected>
+          false
+        </isEventExpected>
+        ...
+      </expectEmit>
+      <whitelist>
+        <isCallWhitelistActive>
+          false
+        </isCallWhitelistActive>
+        <allowedCallsList>
+          .List
+        </allowedCallsList>
+        <isStorageWhitelistActive>
+          false
+        </isStorageWhitelistActive>
+        <storageSlotList>
+          .List
+        </storageSlotList>
+      </whitelist>
+      <mockCalls>
+        .MockCallCellMap
+      </mockCalls>
+      <mockFunctions>
+        .MockFunctionCellMap
+      </mockFunctions>
+    </cheatcodes>
+  </foundry>
+  ...
+</generatedTop>
+#And ( { KV2_z:Int #Equals 0 }
+#And ( #Not ( { KV0_x:Int #Equals 0 } )
+#And ( { true #Equals KV2_z:Int <Int 2 }
+#And ( { true #Equals 0 <=Int KV0_x:Int }
+#And ( { true #Equals 0 <=Int KV1_y:Int }
+#And ( { true #Equals 0 <=Int KV2_z:Int }
+#And ( { true #Equals pow24 <Int NUMBER_CELL:Int }
+#And ( { true #Equals NUMBER_CELL:Int <Int pow32 }
+#And ( { true #Equals 1073741824 <Int TIMESTAMP_CELL:Int }
+#And ( { true #Equals TIMESTAMP_CELL:Int <Int 34359738368 }
+#And ( { true #Equals KV0_x:Int <Int pow256 }
+#And ( { true #Equals KV1_y:Int <Int pow256 }
+#And ( { true #Equals KV0_x:Int <=Int ( maxUInt256 -Int KV1_y:Int ) }
+#And { true #Equals maxUInt256 /Word KV0_x:Int <Int KV1_y:Int } ) ) ) ) ) ) ) ) ) ) ) ) ) )
 
 
 
@@ -500,7 +1626,7 @@ module SUMMARY-TEST%MERGEKCFGTEST.TEST-BRANCH-MERGE(UINT256,UINT256,BOOL):0
                )))))))
       [priority(20), label(BASIC-BLOCK-1-TO-17)]
     
-    rule [BASIC-BLOCK-19-TO-39]: <foundry>
+    rule [BASIC-BLOCK-17-TO-46]: <foundry>
            <kevm>
              <k>
                ( JUMPI 99 bool2Word ( KV2_z:Int ==Int 0 )
@@ -663,7 +1789,7 @@ module SUMMARY-TEST%MERGEKCFGTEST.TEST-BRANCH-MERGE(UINT256,UINT256,BOOL):0
                      ( #address ( FoundryTest ) => 137122462167341575662000267002353578582749290296 )
                    </caller>
                    <callData>
-                     ( b"\xe0~\\\x97" => b"\x15T\xa2\xa4" ) +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes #buf ( 32 , KV2_z:Int )
+                     ( b"\xe0~\\\x97" => b"\x15T\xa2\xa4" ) +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes ( #buf ( 32 , KV2_z:Int ) => ?V_52662f80 )
                    </callData>
                    <callValue>
                      0
@@ -672,7 +1798,7 @@ module SUMMARY-TEST%MERGEKCFGTEST.TEST-BRANCH-MERGE(UINT256,UINT256,BOOL):0
                      ( ( 0 => 357868196 ) : ( ( KV2_z:Int : ( KV1_y:Int : ( KV0_x:Int : ( 60 : ( 3766377623 : .WordStack ) ) ) ) ) => .WordStack ) )
                    </wordStack>
                    <localMem>
-                     ( b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80" => b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xa0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +Bytes #buf ( 32 , ( KV0_x:Int +Int KV1_y:Int ) ) +Bytes #range ( #buf ( 32 , KV0_x:Int ) , 28 , 4 ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes #buf ( 32 , KV2_z:Int ) )
+                     ( b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80" => ?V_4c4917e5 +Bytes ?V_70719e1c +Bytes ?V_681e5d28 +Bytes ?V_d315c49d )
                    </localMem>
                    <memoryUsed>
                      0
@@ -702,7 +1828,7 @@ module SUMMARY-TEST%MERGEKCFGTEST.TEST-BRANCH-MERGE(UINT256,UINT256,BOOL):0
                      0
                    </refund>
                    <accessedAccounts>
-                     ( SetItem ( #address ( FoundryCheat ) ) ( SetItem ( #address ( FoundryTest ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) ) )
+                     ( SetItem ( ( 491460923342184218035706888008750043977755113263 => ?V_762160e3 ) ) ( ( SetItem ( #address ( FoundryCheat ) ) SetItem ( #address ( FoundryTest ) ) ) => ?V_78461641 ) )
                    </accessedAccounts>
                    <accessedStorage>
                      .Map
@@ -855,8 +1981,7 @@ module SUMMARY-TEST%MERGEKCFGTEST.TEST-BRANCH-MERGE(UINT256,UINT256,BOOL):0
              </mockFunctions>
            </cheatcodes>
          </foundry>
-      requires ( KV2_z:Int =/=Int 0
-       andBool ( KV2_z:Int <Int 2
+      requires ( KV2_z:Int <Int 2
        andBool ( 0 <=Int KV0_x:Int
        andBool ( 0 <=Int KV1_y:Int
        andBool ( 0 <=Int KV2_z:Int
@@ -867,757 +1992,53 @@ module SUMMARY-TEST%MERGEKCFGTEST.TEST-BRANCH-MERGE(UINT256,UINT256,BOOL):0
        andBool ( KV0_x:Int <Int pow256
        andBool ( KV1_y:Int <Int pow256
        andBool ( KV0_x:Int <=Int ( maxUInt256 -Int KV1_y:Int )
-               ))))))))))))
-      [priority(20), label(BASIC-BLOCK-19-TO-39)]
-    
-    rule [BASIC-BLOCK-44-TO-42]: <foundry>
-           <kevm>
-             <k>
-               ( JUMPI 99 bool2Word ( KV2_z:Int ==Int 0 )
-               ~> #pc [ JUMPI ]
-               ~> #execute
-               ~> #return 128 32
-               ~> #pc [ CALL ]
-               ~> #execute => #halt ~> .K )
-               ~> _CONTINUATION:K
-             </k>
-             <mode>
-               NORMAL
-             </mode>
-             <schedule>
-               CANCUN
-             </schedule>
-             <useGas>
-               false
-             </useGas>
-             <ethereum>
-               <evm>
-                 <output>
-                   b""
-                 </output>
-                 <statusCode>
-                   ( _STATUSCODE:StatusCode => EVMC_SUCCESS )
-                 </statusCode>
-                 <callStack>
-                   ( ListItem ( <callState>
-                     <id>
-                       #address ( FoundryTest )
-                     </id>
-                     <caller>
-                       137122462167341575662000267002353578582749290296
-                     </caller>
-                     <callData>
-                       b"\x15T\xa2\xa4" +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes #buf ( 32 , KV2_z:Int )
-                     </callData>
-                     <callValue>
-                       0
-                     </callValue>
-                     <wordStack>
-                       ( 228 : ( 3766377623 : ( 491460923342184218035706888008750043977755113263 : ( KV2_z:Int : ( KV1_y:Int : ( KV0_x:Int : ( 193 : ( 357868196 : .WordStack ) ) ) ) ) ) ) )
-                     </wordStack>
-                     <localMem>
-                       b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xe0~\\\x97" +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes #buf ( 32 , KV2_z:Int )
-                     </localMem>
-                     <memoryUsed>
-                       0
-                     </memoryUsed>
-                     <callGas>
-                       0
-                     </callGas>
-                     <static>
-                       false
-                     </static>
-                     <callDepth>
-                       0
-                     </callDepth>
-                     <codeAddr>
-                       #address ( FoundryTest )
-                     </codeAddr>
-                     ...
-                   </callState> ) => .List )
-                 </callStack>
-                 <interimStates>
-                   ( ListItem ( { <accounts>
-                     ( <account>
-                       <acctID>
-                         #address ( FoundryCheat )
-                       </acctID>
-                       <balance>
-                         0
-                       </balance>
-                       <storage>
-                         .Map
-                       </storage>
-                       <origStorage>
-                         .Map
-                       </origStorage>
-                       <transientStorage>
-                         .Map
-                       </transientStorage>
-                       <nonce>
-                         0
-                       </nonce>
-                       ...
-                     </account>
-                     ( <account>
-                       <acctID>
-                         #address ( FoundryTest )
-                       </acctID>
-                       <balance>
-                         maxUInt96
-                       </balance>
-                       <storage>
-                         ( 27 |-> 491460923342184218035706888008750043977755113263 )
-                       </storage>
-                       <origStorage>
-                         .Map
-                       </origStorage>
-                       <transientStorage>
-                         .Map
-                       </transientStorage>
-                       <nonce>
-                         2
-                       </nonce>
-                       ...
-                     </account>
-                     <account>
-                       <acctID>
-                         491460923342184218035706888008750043977755113263
-                       </acctID>
-                       <balance>
-                         0
-                       </balance>
-                       <storage>
-                         .Map
-                       </storage>
-                       <origStorage>
-                         .Map
-                       </origStorage>
-                       <transientStorage>
-                         .Map
-                       </transientStorage>
-                       <nonce>
-                         1
-                       </nonce>
-                       ...
-                     </account> ) )
-                   </accounts> | <substate>
-                     <selfDestruct>
-                       SELFDESTRUCT_CELL:Set
-                     </selfDestruct>
-                     <log>
-                       .List
-                     </log>
-                     <refund>
-                       0
-                     </refund>
-                     <accessedAccounts>
-                       ( SetItem ( #address ( FoundryCheat ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) )
-                     </accessedAccounts>
-                     <accessedStorage>
-                       .Map
-                     </accessedStorage>
-                     <createdAccounts>
-                       .Set
-                     </createdAccounts>
-                   </substate> } ) => .List )
-                 </interimStates>
-                 <touchedAccounts>
-                   ( SetItem ( #address ( FoundryTest ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) )
-                 </touchedAccounts>
-                 <callState>
-                   <id>
-                     ( 491460923342184218035706888008750043977755113263 => #address ( FoundryTest ) )
-                   </id>
-                   <caller>
-                     ( #address ( FoundryTest ) => 137122462167341575662000267002353578582749290296 )
-                   </caller>
-                   <callData>
-                     ( b"\xe0~\\\x97" => b"\x15T\xa2\xa4" ) +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes ( #buf ( 32 , KV2_z:Int ) => b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" )
-                   </callData>
-                   <callValue>
-                     0
-                   </callValue>
-                   <wordStack>
-                     ( ( 0 => 357868196 ) : ( ( KV2_z:Int : ( KV1_y:Int : ( KV0_x:Int : ( 60 : ( 3766377623 : .WordStack ) ) ) ) ) => .WordStack ) )
-                   </wordStack>
-                   <localMem>
-                     ( b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80" => b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xa0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +Bytes #buf ( 32 , chop ( ( KV0_x:Int *Int KV1_y:Int ) ) ) +Bytes #range ( #buf ( 32 , KV0_x:Int ) , 28 , 4 ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" )
-                   </localMem>
-                   <memoryUsed>
-                     0
-                   </memoryUsed>
-                   <callGas>
-                     0
-                   </callGas>
-                   <static>
-                     false
-                   </static>
-                   <callDepth>
-                     ( 1 => 0 )
-                   </callDepth>
-                   <codeAddr>
-                     ( 491460923342184218035706888008750043977755113263 => #address ( FoundryTest ) )
-                   </codeAddr>
-                   ...
-                 </callState>
-                 <substate>
-                   <selfDestruct>
-                     SELFDESTRUCT_CELL:Set
-                   </selfDestruct>
-                   <log>
-                     .List
-                   </log>
-                   <refund>
-                     0
-                   </refund>
-                   <accessedAccounts>
-                     ( SetItem ( #address ( FoundryCheat ) ) ( SetItem ( #address ( FoundryTest ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) ) )
-                   </accessedAccounts>
-                   <accessedStorage>
-                     .Map
-                   </accessedStorage>
-                   <createdAccounts>
-                     .Set
-                   </createdAccounts>
-                 </substate>
-                 <origin>
-                   137122462167341575662000267002353578582749290296
-                 </origin>
-                 <block>
-                   <number>
-                     NUMBER_CELL:Int
-                   </number>
-                   <timestamp>
-                     TIMESTAMP_CELL:Int
-                   </timestamp>
-                   ...
-                 </block>
-                 ...
-               </evm>
-               <network>
-                 <chainID>
-                   1
-                 </chainID>
-                 <accounts>
-                   ( <account>
-                     <acctID>
-                       #address ( FoundryCheat )
-                     </acctID>
-                     <balance>
-                       0
-                     </balance>
-                     <storage>
-                       .Map
-                     </storage>
-                     <origStorage>
-                       .Map
-                     </origStorage>
-                     <transientStorage>
-                       .Map
-                     </transientStorage>
-                     <nonce>
-                       0
-                     </nonce>
-                     ...
-                   </account>
-                   ( <account>
-                     <acctID>
-                       #address ( FoundryTest )
-                     </acctID>
-                     <balance>
-                       maxUInt96
-                     </balance>
-                     <storage>
-                       ( 27 |-> 491460923342184218035706888008750043977755113263 )
-                     </storage>
-                     <origStorage>
-                       .Map
-                     </origStorage>
-                     <transientStorage>
-                       .Map
-                     </transientStorage>
-                     <nonce>
-                       2
-                     </nonce>
-                     ...
-                   </account>
-                   <account>
-                     <acctID>
-                       491460923342184218035706888008750043977755113263
-                     </acctID>
-                     <balance>
-                       0
-                     </balance>
-                     <storage>
-                       .Map
-                     </storage>
-                     <origStorage>
-                       .Map
-                     </origStorage>
-                     <transientStorage>
-                       .Map
-                     </transientStorage>
-                     <nonce>
-                       1
-                     </nonce>
-                     ...
-                   </account> ) )
-                 </accounts>
-                 ...
-               </network>
-             </ethereum>
-             ...
-           </kevm>
-           <stackChecks>
-             true
-           </stackChecks>
-           <cheatcodes>
-             <prank>
-               <active>
-                 false
-               </active>
-               <singleCall>
-                 false
-               </singleCall>
-               ...
-             </prank>
-             <expectedRevert>
-               <isRevertExpected>
-                 false
-               </isRevertExpected>
-               ...
-             </expectedRevert>
-             <expectedOpcode>
-               <isOpcodeExpected>
-                 false
-               </isOpcodeExpected>
-               ...
-             </expectedOpcode>
-             <expectEmit>
-               <recordEvent>
-                 false
-               </recordEvent>
-               <isEventExpected>
-                 false
-               </isEventExpected>
-               ...
-             </expectEmit>
-             <whitelist>
-               <isCallWhitelistActive>
-                 false
-               </isCallWhitelistActive>
-               <allowedCallsList>
-                 .List
-               </allowedCallsList>
-               <isStorageWhitelistActive>
-                 false
-               </isStorageWhitelistActive>
-               <storageSlotList>
-                 .List
-               </storageSlotList>
-             </whitelist>
-             <mockCalls>
-               .MockCallCellMap
-             </mockCalls>
-             <mockFunctions>
-               .MockFunctionCellMap
-             </mockFunctions>
-           </cheatcodes>
-         </foundry>
-      requires ( KV2_z:Int ==Int 0
-       andBool ( KV2_z:Int <Int 2
-       andBool ( 0 <=Int KV0_x:Int
-       andBool ( 0 <=Int KV1_y:Int
-       andBool ( 0 <=Int KV2_z:Int
-       andBool ( pow24 <Int NUMBER_CELL:Int
-       andBool ( NUMBER_CELL:Int <Int pow32
-       andBool ( 1073741824 <Int TIMESTAMP_CELL:Int
-       andBool ( TIMESTAMP_CELL:Int <Int 34359738368
-       andBool ( KV0_x:Int <Int pow256
-       andBool ( KV1_y:Int <Int pow256
-       andBool ( KV0_x:Int <=Int ( maxUInt256 -Int KV1_y:Int )
-       andBool ( ( KV0_x:Int ==Int 0
-          orBool ( KV1_y:Int <=Int maxUInt256 /Word KV0_x:Int
-                 ))
-               )))))))))))))
-      [priority(20), label(BASIC-BLOCK-44-TO-42)]
-    
-    rule [BASIC-BLOCK-45-TO-43]: <foundry>
-           <kevm>
-             <k>
-               ( JUMPI 99 bool2Word ( KV2_z:Int ==Int 0 )
-               ~> #pc [ JUMPI ]
-               ~> #execute
-               ~> #return 128 32
-               ~> #pc [ CALL ]
-               ~> #execute => #halt ~> .K )
-               ~> _CONTINUATION:K
-             </k>
-             <mode>
-               NORMAL
-             </mode>
-             <schedule>
-               CANCUN
-             </schedule>
-             <useGas>
-               false
-             </useGas>
-             <ethereum>
-               <evm>
-                 <output>
-                   b""
-                 </output>
-                 <statusCode>
-                   ( _STATUSCODE:StatusCode => EVMC_SUCCESS )
-                 </statusCode>
-                 <callStack>
-                   ( ListItem ( <callState>
-                     <id>
-                       #address ( FoundryTest )
-                     </id>
-                     <caller>
-                       137122462167341575662000267002353578582749290296
-                     </caller>
-                     <callData>
-                       b"\x15T\xa2\xa4" +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes #buf ( 32 , KV2_z:Int )
-                     </callData>
-                     <callValue>
-                       0
-                     </callValue>
-                     <wordStack>
-                       ( 228 : ( 3766377623 : ( 491460923342184218035706888008750043977755113263 : ( KV2_z:Int : ( KV1_y:Int : ( KV0_x:Int : ( 193 : ( 357868196 : .WordStack ) ) ) ) ) ) ) )
-                     </wordStack>
-                     <localMem>
-                       b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xe0~\\\x97" +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes #buf ( 32 , KV2_z:Int )
-                     </localMem>
-                     <memoryUsed>
-                       0
-                     </memoryUsed>
-                     <callGas>
-                       0
-                     </callGas>
-                     <static>
-                       false
-                     </static>
-                     <callDepth>
-                       0
-                     </callDepth>
-                     <codeAddr>
-                       #address ( FoundryTest )
-                     </codeAddr>
-                     ...
-                   </callState> ) => .List )
-                 </callStack>
-                 <interimStates>
-                   ( ListItem ( { <accounts>
-                     ( <account>
-                       <acctID>
-                         #address ( FoundryCheat )
-                       </acctID>
-                       <balance>
-                         0
-                       </balance>
-                       <storage>
-                         .Map
-                       </storage>
-                       <origStorage>
-                         .Map
-                       </origStorage>
-                       <transientStorage>
-                         .Map
-                       </transientStorage>
-                       <nonce>
-                         0
-                       </nonce>
-                       ...
-                     </account>
-                     ( <account>
-                       <acctID>
-                         #address ( FoundryTest )
-                       </acctID>
-                       <balance>
-                         maxUInt96
-                       </balance>
-                       <storage>
-                         ( 27 |-> 491460923342184218035706888008750043977755113263 )
-                       </storage>
-                       <origStorage>
-                         .Map
-                       </origStorage>
-                       <transientStorage>
-                         .Map
-                       </transientStorage>
-                       <nonce>
-                         2
-                       </nonce>
-                       ...
-                     </account>
-                     <account>
-                       <acctID>
-                         491460923342184218035706888008750043977755113263
-                       </acctID>
-                       <balance>
-                         0
-                       </balance>
-                       <storage>
-                         .Map
-                       </storage>
-                       <origStorage>
-                         .Map
-                       </origStorage>
-                       <transientStorage>
-                         .Map
-                       </transientStorage>
-                       <nonce>
-                         1
-                       </nonce>
-                       ...
-                     </account> ) )
-                   </accounts> | <substate>
-                     <selfDestruct>
-                       SELFDESTRUCT_CELL:Set
-                     </selfDestruct>
-                     <log>
-                       .List
-                     </log>
-                     <refund>
-                       0
-                     </refund>
-                     <accessedAccounts>
-                       ( SetItem ( #address ( FoundryCheat ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) )
-                     </accessedAccounts>
-                     <accessedStorage>
-                       .Map
-                     </accessedStorage>
-                     <createdAccounts>
-                       .Set
-                     </createdAccounts>
-                   </substate> } ) => .List )
-                 </interimStates>
-                 <touchedAccounts>
-                   ( SetItem ( #address ( FoundryTest ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) )
-                 </touchedAccounts>
-                 <callState>
-                   <id>
-                     ( 491460923342184218035706888008750043977755113263 => #address ( FoundryTest ) )
-                   </id>
-                   <caller>
-                     ( #address ( FoundryTest ) => 137122462167341575662000267002353578582749290296 )
-                   </caller>
-                   <callData>
-                     ( b"\xe0~\\\x97" => b"\x15T\xa2\xa4" ) +Bytes #buf ( 32 , KV0_x:Int ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes ( #buf ( 32 , KV2_z:Int ) => b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" )
-                   </callData>
-                   <callValue>
-                     0
-                   </callValue>
-                   <wordStack>
-                     ( ( 0 => 357868196 ) : ( ( KV2_z:Int : ( KV1_y:Int : ( KV0_x:Int : ( 60 : ( 3766377623 : .WordStack ) ) ) ) ) => .WordStack ) )
-                   </wordStack>
-                   <localMem>
-                     ( b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80" => b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00NH{q\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +Bytes #range ( #buf ( 32 , KV0_x:Int ) , 28 , 4 ) +Bytes #buf ( 32 , KV1_y:Int ) +Bytes b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" )
-                   </localMem>
-                   <memoryUsed>
-                     0
-                   </memoryUsed>
-                   <callGas>
-                     0
-                   </callGas>
-                   <static>
-                     false
-                   </static>
-                   <callDepth>
-                     ( 1 => 0 )
-                   </callDepth>
-                   <codeAddr>
-                     ( 491460923342184218035706888008750043977755113263 => #address ( FoundryTest ) )
-                   </codeAddr>
-                   ...
-                 </callState>
-                 <substate>
-                   <selfDestruct>
-                     SELFDESTRUCT_CELL:Set
-                   </selfDestruct>
-                   <log>
-                     .List
-                   </log>
-                   <refund>
-                     0
-                   </refund>
-                   <accessedAccounts>
-                     ( SetItem ( 491460923342184218035706888008750043977755113263 ) ( ( SetItem ( #address ( FoundryCheat ) ) SetItem ( #address ( FoundryTest ) ) ) => SetItem ( #address ( FoundryCheat ) ) ) )
-                   </accessedAccounts>
-                   <accessedStorage>
-                     .Map
-                   </accessedStorage>
-                   <createdAccounts>
-                     .Set
-                   </createdAccounts>
-                 </substate>
-                 <origin>
-                   137122462167341575662000267002353578582749290296
-                 </origin>
-                 <block>
-                   <number>
-                     NUMBER_CELL:Int
-                   </number>
-                   <timestamp>
-                     TIMESTAMP_CELL:Int
-                   </timestamp>
-                   ...
-                 </block>
-                 ...
-               </evm>
-               <network>
-                 <chainID>
-                   1
-                 </chainID>
-                 <accounts>
-                   ( <account>
-                     <acctID>
-                       #address ( FoundryCheat )
-                     </acctID>
-                     <balance>
-                       0
-                     </balance>
-                     <storage>
-                       .Map
-                     </storage>
-                     <origStorage>
-                       .Map
-                     </origStorage>
-                     <transientStorage>
-                       .Map
-                     </transientStorage>
-                     <nonce>
-                       0
-                     </nonce>
-                     ...
-                   </account>
-                   ( <account>
-                     <acctID>
-                       #address ( FoundryTest )
-                     </acctID>
-                     <balance>
-                       maxUInt96
-                     </balance>
-                     <storage>
-                       ( 27 |-> 491460923342184218035706888008750043977755113263 )
-                     </storage>
-                     <origStorage>
-                       .Map
-                     </origStorage>
-                     <transientStorage>
-                       .Map
-                     </transientStorage>
-                     <nonce>
-                       2
-                     </nonce>
-                     ...
-                   </account>
-                   <account>
-                     <acctID>
-                       491460923342184218035706888008750043977755113263
-                     </acctID>
-                     <balance>
-                       0
-                     </balance>
-                     <storage>
-                       .Map
-                     </storage>
-                     <origStorage>
-                       .Map
-                     </origStorage>
-                     <transientStorage>
-                       .Map
-                     </transientStorage>
-                     <nonce>
-                       1
-                     </nonce>
-                     ...
-                   </account> ) )
-                 </accounts>
-                 ...
-               </network>
-             </ethereum>
-             ...
-           </kevm>
-           <stackChecks>
-             true
-           </stackChecks>
-           <cheatcodes>
-             <prank>
-               <active>
-                 false
-               </active>
-               <singleCall>
-                 false
-               </singleCall>
-               ...
-             </prank>
-             <expectedRevert>
-               <isRevertExpected>
-                 false
-               </isRevertExpected>
-               ...
-             </expectedRevert>
-             <expectedOpcode>
-               <isOpcodeExpected>
-                 false
-               </isOpcodeExpected>
-               ...
-             </expectedOpcode>
-             <expectEmit>
-               <recordEvent>
-                 false
-               </recordEvent>
-               <isEventExpected>
-                 false
-               </isEventExpected>
-               ...
-             </expectEmit>
-             <whitelist>
-               <isCallWhitelistActive>
-                 false
-               </isCallWhitelistActive>
-               <allowedCallsList>
-                 .List
-               </allowedCallsList>
-               <isStorageWhitelistActive>
-                 false
-               </isStorageWhitelistActive>
-               <storageSlotList>
-                 .List
-               </storageSlotList>
-             </whitelist>
-             <mockCalls>
-               .MockCallCellMap
-             </mockCalls>
-             <mockFunctions>
-               .MockFunctionCellMap
-             </mockFunctions>
-           </cheatcodes>
-         </foundry>
-      requires ( KV2_z:Int ==Int 0
-       andBool ( KV0_x:Int =/=Int 0
-       andBool ( KV2_z:Int <Int 2
-       andBool ( 0 <=Int KV0_x:Int
-       andBool ( 0 <=Int KV1_y:Int
-       andBool ( 0 <=Int KV2_z:Int
-       andBool ( pow24 <Int NUMBER_CELL:Int
-       andBool ( NUMBER_CELL:Int <Int pow32
-       andBool ( 1073741824 <Int TIMESTAMP_CELL:Int
-       andBool ( TIMESTAMP_CELL:Int <Int 34359738368
-       andBool ( KV0_x:Int <Int pow256
-       andBool ( KV1_y:Int <Int pow256
-       andBool ( KV0_x:Int <=Int ( maxUInt256 -Int KV1_y:Int )
-       andBool ( maxUInt256 /Word KV0_x:Int <Int KV1_y:Int
-               ))))))))))))))
-       ensures ( maxUInt256 /Int KV0_x:Int ) <Int KV1_y:Int
-      [priority(20), label(BASIC-BLOCK-45-TO-43)]
+               )))))))))))
+       ensures ( ( ?V_52662f80 ==K ?V_8d5dd32b
+         andBool ( ?V_4c4917e5 ==K b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xa0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+         andBool ( ?V_70719e1c ==K #buf ( 32 , ?V_30bef23e )
+         andBool ( ?V_681e5d28 ==K #range ( #buf ( 32 , KV0_x:Int ) , 28 , 4 )
+         andBool ( ?V_d315c49d ==K #buf ( 32 , KV1_y:Int ) +Bytes ?V_8d5dd32b
+         andBool ( ?V_762160e3 ==K #address ( FoundryTest )
+         andBool ( ?V_78461641 ==K ( SetItem ( #address ( FoundryCheat ) ) SetItem ( 491460923342184218035706888008750043977755113263 ) )
+         andBool ( ( ( ?V_8d5dd32b ==K #buf ( 32 , KV2_z:Int )
+             andBool ( ?V_30bef23e ==K ( KV0_x:Int +Int KV1_y:Int )
+             andBool ( KV2_z:Int <Int 2
+             andBool ( 0 <=Int KV2_z:Int
+             andBool ( KV2_z:Int =/=Int 0
+                     )))))
+            orBool ( ( ?V_8d5dd32b ==K b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+             andBool ( ?V_30bef23e ==K chop ( ( KV0_x:Int *Int KV1_y:Int ) )
+             andBool ( KV2_z:Int ==Int 0
+             andBool ( ( KV0_x:Int ==Int 0
+                orBool ( KV1_y:Int <=Int maxUInt256 /Word KV0_x:Int
+                       ))
+                     ))))
+                   ))
+                 ))))))))
+        orBool ( ( ?V_52662f80 ==K b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+         andBool ( ?V_4c4917e5 ==K b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00NH{q\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+         andBool ( ?V_70719e1c ==K #range ( #buf ( 32 , KV0_x:Int ) , 28 , 4 )
+         andBool ( ?V_681e5d28 ==K #buf ( 32 , KV1_y:Int )
+         andBool ( ?V_d315c49d ==K b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+         andBool ( ?V_762160e3 ==K 491460923342184218035706888008750043977755113263
+         andBool ( ?V_78461641 ==K SetItem ( #address ( FoundryCheat ) )
+         andBool ( KV2_z:Int ==Int 0
+         andBool ( KV0_x:Int =/=Int 0
+         andBool ( ( maxUInt256 /Int KV0_x:Int ) <Int KV1_y:Int
+                 ))))))))))
+               ))
+      [priority(20), label(BASIC-BLOCK-17-TO-46)]
 
 endmodule
-0 Failure nodes. (0 pending and 0 failing)
+3 Failure nodes. (3 pending and 0 failing)
+
+Pending nodes:
+
+ID: 19:
+
+ID: 44:
+
+ID: 45:
 
 Join the Runtime Verification Discord server (https://discord.com/invite/CurfmXNtbN) or Telegram group (https://t.me/rv_kontrol) for support.
 


### PR DESCRIPTION
This PR makes proof minimization in Kontrol use the Kontrol/KEVM heuristic for determining whether nodes are mergeable, thereby fixing the issue with nodes not getting merged with `kontrol minimize-proof --merge`.

~TODO: expected output update is probably needed.~