### PR TITLE
Fix counterexample indentation

### DIFF
--- a/src/kontrol/counterexample_generation.py
+++ b/src/kontrol/counterexample_generation.py
@@ -306,8 +306,7 @@ def _extract_and_modify_function(
         count=1,
     )
 
-    indented_func = '    ' + func_text.replace('\n', '\n    ')
-    return '\n' + indented_func
+    return '\n' + func_text
 
 
 def _insert_assignments_into_function(

--- a/src/kontrol/counterexample_generation.py
+++ b/src/kontrol/counterexample_generation.py
@@ -298,15 +298,16 @@ def _extract_and_modify_function(
 
     func_text = m.group(1)
 
-    # Rename the function
+    # Rename the function and remove all parameters
     func_text = re.sub(
-        rf'function\s+{re.escape(original_method_name)}\s*\(',
-        f'function {new_method_name}(',
+        rf'function\s+{re.escape(original_method_name)}\s*\([^)]*\)',
+        f'function {new_method_name}()',
         func_text,
         count=1,
     )
 
-    return '\n' + func_text
+    indented_func = '    ' + func_text
+    return '\n' + indented_func
 
 
 def _insert_assignments_into_function(
@@ -323,7 +324,7 @@ def _insert_assignments_into_function(
     """
     text = content
 
-    # 1) Find the start of the target function signature: `function <name>(`
+    # Find the start of the target function signature: `function <name>(`
     sig_needle = f'function {method_name}('
     sig_pos = text.find(sig_needle)
     if sig_pos == -1:
@@ -333,7 +334,7 @@ def _insert_assignments_into_function(
             return text
         sig_pos = m.start()
 
-    # 2) From the first '(' after the method name, find the matching ')'
+    # From the first '(' after the method name, find the matching ')'
     paren_start = text.find('(', sig_pos)
     if paren_start == -1:
         return text
@@ -352,18 +353,17 @@ def _insert_assignments_into_function(
         return text
     paren_end = i  # index of the closing ')'
 
-    # 3) After the signature, skip whitespace/modifiers until the opening '{'
+    # After the signature, skip whitespace/modifiers until the opening '{'
     j = paren_end + 1
     while j < len(text) and text[j].isspace():
         j += 1
 
     # Skip modifier/returns tokens until '{'
-    # (We don't try to parse them; just scan until first '{')
     brace_pos = text.find('{', j)
     if brace_pos == -1:
         return text
 
-    # 4) Find the end of the function by brace counting from this '{'
+    # Find the end of the function by brace counting from this '{'
     depth = 0
     k = brace_pos
     while k < len(text):
@@ -380,7 +380,7 @@ def _insert_assignments_into_function(
     func_body_open = brace_pos
     func_end = k  # index of the matching closing '}'
 
-    # 5) Extract params to map assignments
+    # Extract params to map assignments
     params_segment = text[paren_start + 1 : paren_end].strip()
     actual_param_names: list[str] = []
     param_types: dict[str, str] = {}
@@ -394,7 +394,7 @@ def _insert_assignments_into_function(
                 actual_param_names.append(pname)
                 param_types[pname] = ptype
 
-    # 6) Build assignment lines
+    # Build assignment lines
     def _lookup_value(name: str) -> Any | None:
         if name in concrete_values:
             return concrete_values[name]
@@ -411,18 +411,18 @@ def _insert_assignments_into_function(
         if v is None:
             continue
         ptype = param_types.get(pname, 'uint256')
-        assignments.append(f'        {pname} = {_format_value(v, ptype)};')
+        assignments.append(f'        {ptype} {pname} = {_format_value(v, ptype)};')
 
     if not assignments:
         # Nothing to insert; keep function unchanged
         return text
 
-    # 7) Idempotence: if marker already inside this function, do nothing
+    # If marker already inside this function, do not add assignments
     func_block = text[func_start : func_end + 1]
     if _ASSIGNMENT_MARKER in func_block:
         return text
 
-    # 8) Insert assignments right after the opening '{'
+    # Insert assignments after the opening '{'
     insert_block = '        ' + _ASSIGNMENT_MARKER + '\n' + '\n'.join(assignments) + '\n'
     new_text = text[: func_body_open + 1] + '\n' + insert_block + text[func_body_open + 1 :]
 

--- a/src/tests/integration/test-data/show/UnitTestCounterexampleTest.expected
+++ b/src/tests/integration/test-data/show/UnitTestCounterexampleTest.expected
@@ -457,13 +457,13 @@ contract UnitTest is Test {
     }
 
 
-    function test_counterexample_ce0(uint256 value, address addr, bool flag) public pure {
-            // Counterexample values from failed proof:
-            value = 10;
-            addr = address(0);
-            flag = false;
-    
-            // This test will fail, triggering counterexample generation
-            assert(value != 10);
-        }
+    function test_counterexample_ce0() public pure {
+        // Counterexample values from failed proof:
+        uint256 value = 10;
+        address addr = address(0);
+        bool flag = false;
+
+        // This test will fail, triggering counterexample generation
+        assert(value != 10);
+    }
 }


### PR DESCRIPTION
Follow up to https://github.com/runtimeverification/kontrol/pull/1084.

This PR improves the consistency of the indentation in the generated counterexamples and changes the signature of the counterexample function, turning it into a unit test that doesn't accept arguments, for example:

```solidity 
    function test_counterexample_ce0() public pure {
        // Counterexample values from failed proof:
        uint256 value = 10;
        address addr = address(0);
        bool flag = false;

        // This test will fail, triggering counterexample generation
        assert(value != 10);
    }
```

instead of the previous version:
```solidity
    function test_counterexample_ce0(uint256 value, address addr, bool flag) public pure {
            // Counterexample values from failed proof:
            value = 10;
            addr = address(0);
            flag = false;
    
            // This test will fail, triggering counterexample generation
            assert(value != 10);
        }
```