### PR TITLE
Add `pyproject-nix` overlay

### DIFF
--- a/nix/kontrol-pyk-pyproject/default.nix
+++ b/nix/kontrol-pyk-pyproject/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  callPackage,
+  nix-gitignore,
+  stdenvNoCC,
+
+  uv2nix,
+  solc_version ? null,
+}:
+let
+  # patches cannot yet be applied to uv workspaces, so we use a derivation containing the src instead
+  src = stdenvNoCC.mkDerivation {
+    name = "kontrol-pyk-src";
+    src = callPackage ../kontrol-source { };
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    postPatch = ''
+      ${lib.strings.optionalString (solc_version != null) ''
+        substituteInPlace ./src/kontrol/foundry.py \
+          --replace "'forge', 'build'," "'forge', 'build', '--no-auto-detect',"
+      ''}
+    '';
+
+    installPhase = ''
+      mkdir -p $out
+      cp -r . $out/
+    '';
+  };
+
+  # load a uv workspace from a workspace root
+  workspace = uv2nix.lib.workspace.loadWorkspace {
+    workspaceRoot = "${src}";
+  };
+
+  # create overlay
+  lockFileOverlay = workspace.mkPyprojectOverlay {
+    # prefer "wheel" over "sdist" due to maintance overhead
+    # there is no bundled set of overlays for "sdist" in uv2nix, in contrast to poetry2nix
+    sourcePreference = "wheel";
+  };
+in {
+  inherit lockFileOverlay workspace;
+}

--- a/nix/kontrol-pyk/default.nix
+++ b/nix/kontrol-pyk/default.nix
@@ -1,65 +1,33 @@
 {
   lib,
   callPackage,
-  stdenvNoCC,
 
   pyproject-nix,
   pyproject-build-systems,
-  uv2nix,
+  kontrol-pyk-pyproject,
+  pyproject-overlays ? [ ],
 
-  python,
-  solc_version ? null
+  python
 }:
 let
+  inherit (kontrol-pyk-pyproject) lockFileOverlay workspace;
+
   pyproject-util = callPackage pyproject-nix.build.util {};
   pyproject-packages = callPackage pyproject-nix.build.packages {
     inherit python;
   };
 
-  # patches cannot yet be applied to uv workspaces, so we use a derivation containing the src instead
-  src = stdenvNoCC.mkDerivation {
-    name = "kontrol-pyk-src";
-    src = callPackage ../kontrol-source { };
-
-    dontConfigure = true;
-    dontBuild = true;
-
-    postPatch = ''
-      ${lib.strings.optionalString (solc_version != null) ''
-        substituteInPlace ./src/kontrol/foundry.py \
-          --replace "'forge', 'build'," "'forge', 'build', '--no-auto-detect',"
-      ''}
-    '';
-
-    installPhase = ''
-      mkdir -p $out
-      cp -r . $out/
-    '';
-  };
-
-  # load a uv workspace from a workspace root
-  workspace = uv2nix.lib.workspace.loadWorkspace {
-    workspaceRoot = "${src}";
-  };
-
-  # create overlay
-  lockFileOverlay = workspace.mkPyprojectOverlay {
-    # prefer "wheel" over "sdist" due to maintance overhead
-    # there is no bundled set of overlays for "sdist" in uv2nix, in contrast to poetry2nix
-    sourcePreference = "wheel";
-  };
-
   buildSystemsOverlay = import ./build-systems-overlay.nix;
 
   # construct package set
-  pythonSet = pyproject-packages.overrideScope (lib.composeManyExtensions [
+  pythonSet = pyproject-packages.overrideScope (lib.composeManyExtensions ([
     # make build tools available by default as these are not necessarily specified in python lock files
     pyproject-build-systems.overlays.default
     # include all packages from the python lock file
     lockFileOverlay
     # add build system overrides to certain python packages
     buildSystemsOverlay
-  ]);
+  ] ++ pyproject-overlays));
 in pyproject-util.mkApplication {
   # default dependancy group enables no optional dependencies and no dependency-groups
   venv = pythonSet.mkVirtualEnv "kontrol-pyk-env" workspace.deps.default;

--- a/nix/kontrol/default.nix
+++ b/nix/kontrol/default.nix
@@ -31,7 +31,9 @@
   rev ? null
 } @ args:
 let
-  kontrol-pyk-solc = kontrol-pyk.override { inherit solc_version; };
+  kontrol-pyk-solc = kontrol-pyk.override ( oldArgs: {
+    kontrol-pyk-pyproject = oldArgs.kontrol-pyk-pyproject.override { inherit solc_version; };
+  });
   nixLibs = "-I${openssl.dev}/include -L${openssl.out}/lib -I${secp256k1}/include -L${secp256k1}/lib";
 in
 stdenv.mkDerivation {
@@ -84,10 +86,21 @@ stdenv.mkDerivation {
     } --set NIX_LIBS "${nixLibs}" --set KDIST_DIR $out
   '';
 
-  passthru = if solc_version == null then {
+  passthru = if solc_version == null then
+  let
+    kontrol-pyk-with-solc = new_solc_version: kontrol-pyk.override ( oldArgs: {
+      kontrol-pyk-pyproject = oldArgs.kontrol-pyk-pyproject.override { solc_version = new_solc_version; };
+    });
+  in {
     # list all supported solc versions here
-    solc_0_8_13 = callPackage ./default.nix (args // { solc_version = solc_0_8_13; });
-    solc_0_8_15 = callPackage ./default.nix (args // { solc_version = solc_0_8_15; });
-    solc_0_8_22 = callPackage ./default.nix (args // { solc_version = solc_0_8_22; });
+    solc_0_8_13 = callPackage ./default.nix (args // {
+      kontrol-pyk = kontrol-pyk-with-solc solc_0_8_13;
+    });
+    solc_0_8_15 = callPackage ./default.nix (args // {
+      kontrol-pyk = kontrol-pyk-with-solc solc_0_8_15;
+    });
+    solc_0_8_22 = callPackage ./default.nix (args // {
+      kontrol-pyk = kontrol-pyk-with-solc solc_0_8_22;
+    });
   } else { };
 }


### PR DESCRIPTION
Previously, when RV nix derivations were using `poetry2nix`, overriding a nix input in nix was also overriding the python code and resources used in `poetry2nix`. This allowed for easy overrides of python and K semantics changes by utilizing nix overrides.

With the migration to `uv` and `uv2nix`, this was behavior was removed due to the respective code not documenting it's purpose. In addition, due to `uv2nix` relying on state-of-the-art python nix packaging tooling `pyproject-nix` instead of `nixpkgs`, ensuring identical override behaviour requires more nix logic.

This PR re-introduces this kind of behaviour with `uv2nix`, though it depends on newly introduced overlays in the k nix flake.

### Example
You can override k by running: `kup install kontrol --override kevm/k-framework ~/path/to/local-k-checkout`. This will now also build kontrol with the python and K code in `~/path/to/local-k-checkout`.