### PR TITLE
Introducing changes to fix cachix pin and push failures in CI

### DIFF
--- a/.github/scripts/check-cachix-pin.sh
+++ b/.github/scripts/check-cachix-pin.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Kup relies on cachix registry k-framework-binary.
+CACHE="k-framework-binary"
+OWNER_REPO="${OWNER_REPO:-$(git remote get-url origin | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')}"
+REV="${REV:-${GITHUB_SHA:-$(git rev-parse HEAD)}}"
+UNAME_S="$(uname -s)"
+UNAME_M="$(uname -m)"
+case "${UNAME_S}-${UNAME_M}" in
+  Linux-x86_64) SYSTEM="x86_64-linux" ;;
+  Linux-aarch64 | Linux-arm64) SYSTEM="aarch64-linux" ;;
+  Darwin-x86_64) SYSTEM="x86_64-darwin" ;;
+  Darwin-arm64) SYSTEM="aarch64-darwin" ;;
+  *)
+    echo "Unsupported platform: ${UNAME_S}-${UNAME_M}" >&2
+    exit 1
+    ;;
+esac
+PIN_API_URL="https://app.cachix.org/api/v1/cache/${CACHE}/pin"
+CHECK_PACKAGES=(kontrol kontrol.solc_0_8_13 kontrol.solc_0_8_15)
+
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+{
+  echo "## Cachix Publish Summary"
+  echo "CACHE: $CACHE"
+  echo "OWNER_REPO: $OWNER_REPO"
+  echo "REV: $REV"
+  echo "SYSTEM: $SYSTEM"
+  echo "PACKAGES: ${CHECK_PACKAGES[*]}"
+} >> "$SUMMARY"
+
+# Verify push + pin together for each package. Both can become visible with delay.
+PIN_VISIBILITY_TIMEOUT_SECONDS=120 # 2 minutes
+PIN_VISIBILITY_INTERVAL_SECONDS=5  # 5 seconds
+PIN_VISIBILITY_ATTEMPTS=$((PIN_VISIBILITY_TIMEOUT_SECONDS / PIN_VISIBILITY_INTERVAL_SECONDS))
+for i in $(seq 1 "$PIN_VISIBILITY_ATTEMPTS"); do
+  PIN_JSON="$(curl -fsSL "${PIN_API_URL}?q=${REV}")"
+  ALL_OK=1
+
+  for PKG in "${CHECK_PACKAGES[@]}"; do
+    KEY="github:${OWNER_REPO}/${REV}#packages.${SYSTEM}.${PKG}"
+    STORE_PATH="$(
+      echo "$PIN_JSON" \
+        | jq -r --arg k "$KEY" 'map(select(.name == $k)) | first | (.lastRevision.storePath // .storePath // .store_path // .path // "")'
+    )"
+    if [ -z "$STORE_PATH" ]; then
+      PIN_STATUS="pin-missing"
+      PUSH_STATUS="000"
+      ALL_OK=0
+      {
+        echo "key-${PKG}: ${KEY}"
+        echo "pin-status-${PKG}: ${PIN_STATUS}"
+        echo "push-http-${PKG}: ${PUSH_STATUS}"
+      }
+      continue
+    fi
+
+    PIN_STATUS="pin-ok"
+    HASH="$(basename "$STORE_PATH" | cut -d- -f1)"
+    PUSH_NARINFO_URL="https://${CACHE}.cachix.org/${HASH}.narinfo"
+    PUSH_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' "$PUSH_NARINFO_URL")" || PUSH_STATUS="000"
+    if [ "$PUSH_STATUS" != "200" ]; then
+      ALL_OK=0
+    fi
+
+    {
+      echo "key-${PKG}: ${KEY}"
+      echo "store-path-${PKG}: ${STORE_PATH}"
+      echo "pin-status-${PKG}: ${PIN_STATUS}"
+      echo "push-http-${PKG}: ${PUSH_STATUS}"
+    }
+  done
+
+  if [ "$ALL_OK" = "1" ]; then
+    echo "cachix-status: push-and-pin-ok-for-all-packages" >> "$SUMMARY"
+    exit 0
+  fi
+
+  echo "cachix-check-attempt-${i}: not-ready, retrying in ${PIN_VISIBILITY_INTERVAL_SECONDS}s"
+  sleep "$PIN_VISIBILITY_INTERVAL_SECONDS"
+done
+
+echo "cachix-status: push-or-pin-missing-after-${PIN_VISIBILITY_TIMEOUT_SECONDS}s-for-at-least-one-package" >> "$SUMMARY"
+exit 1

--- a/.github/scripts/check-cachix-pin.sh
+++ b/.github/scripts/check-cachix-pin.sh
@@ -22,6 +22,15 @@ CHECK_PACKAGES=(kontrol kontrol.solc_0_8_13 kontrol.solc_0_8_15)
 
 SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
 
+# Append to the GitHub step summary when set; always print to stdout for live job logs.
+summary_and_log() {
+  if [[ "${SUMMARY}" == "/dev/stdout" ]]; then
+    cat
+  else
+    tee -a "${SUMMARY}"
+  fi
+}
+
 {
   echo "## Cachix Publish Summary"
   echo "CACHE: $CACHE"
@@ -53,7 +62,7 @@ for i in $(seq 1 "$PIN_VISIBILITY_ATTEMPTS"); do
         echo "key-${PKG}: ${KEY}"
         echo "pin-status-${PKG}: ${PIN_STATUS}"
         echo "push-http-${PKG}: ${PUSH_STATUS}"
-      }
+      } | summary_and_log
       continue
     fi
 
@@ -70,7 +79,7 @@ for i in $(seq 1 "$PIN_VISIBILITY_ATTEMPTS"); do
       echo "store-path-${PKG}: ${STORE_PATH}"
       echo "pin-status-${PKG}: ${PIN_STATUS}"
       echo "push-http-${PKG}: ${PUSH_STATUS}"
-    }
+    } | summary_and_log
   done
 
   if [ "$ALL_OK" = "1" ]; then
@@ -78,9 +87,13 @@ for i in $(seq 1 "$PIN_VISIBILITY_ATTEMPTS"); do
     exit 0
   fi
 
-  echo "cachix-check-attempt-${i}: not-ready, retrying in ${PIN_VISIBILITY_INTERVAL_SECONDS}s"
+  RETRY_MSG="cachix-check-attempt-${i}: not-ready, retrying in ${PIN_VISIBILITY_INTERVAL_SECONDS}s"
+  printf '%s\n' "$RETRY_MSG" | summary_and_log
   sleep "$PIN_VISIBILITY_INTERVAL_SECONDS"
 done
 
 echo "cachix-status: push-or-pin-missing-after-${PIN_VISIBILITY_TIMEOUT_SECONDS}s-for-at-least-one-package" >> "$SUMMARY"
+# Pin API bulk JSON goes to job logs only (step summary stays readable); helps if the response shape changes.
+echo "check-cachix-pin: raw Cachix pin API response (last fetch):" >&2
+echo "$PIN_JSON" >&2
 exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,8 @@ jobs:
         env:
           CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_PRIVATE_KFB_TOKEN }}'
           GC_DONT_GC: '1'
+          OWNER_REPO: '${{ github.repository }}'
+          REV: '${{ github.sha }}'
         with:
           packages: jq
           script: |
@@ -89,6 +91,8 @@ jobs:
             kup publish k-framework-binary .#kontrol --keep-days 180
             kup publish k-framework-binary .#kontrol.solc_0_8_13 --keep-days 180
             kup publish k-framework-binary .#kontrol.solc_0_8_15 --keep-days 180
+            # Cachix has not been responding to 'cachix pin' requests made under the hood by kup. Verify the push and pin manually.
+            .github/scripts/check-cachix-pin.sh
 
       - name: 'On failure, delete drafted release'
         if: failure()


### PR DESCRIPTION
Failures with cachix are due to timeouts from cloudflare but the requests still complete. 

Per similar changes in [mir-semantics](https://github.com/runtimeverification/mir-semantics/pull/951/changes#diff-59cd4bfedd5e699e84dab588cd4c5bf931e01b112053cead0f7ce3d708d651d6), applying those changes to kontrol to clean up failed release jobs. 

