### PR TITLE
feat: add `--per-depth-timeout` option for kontrol prove

### DIFF
--- a/src/kontrol/cli.py
+++ b/src/kontrol/cli.py
@@ -554,6 +554,18 @@ def _create_argument_parser() -> ArgumentParser:
         action='store_true',
         help='Generate a Solidity test contract with concrete counterexample values when proofs fail.',
     )
+    prove_args.add_argument(
+        '--per-depth-timeout',
+        type=float,
+        default=None,
+        dest='per_depth_timeout',
+        help=(
+            'Per-depth stall window in seconds. When > 0, each prove attempt has '
+            '`max_depth * per_depth_timeout` seconds without on-disk progress before being killed; '
+            '`max_depth` is then halved and the proof resumes from saved KCFG state. '
+            'Repeats down to depth=1. Default 0 disables progressive halving.'
+        ),
+    )
 
     show_args = command_parser.add_parser(
         'show',

--- a/src/kontrol/options.py
+++ b/src/kontrol/options.py
@@ -343,6 +343,7 @@ class ProveOptions(
     extra_module: str | None
     symbolic_caller: bool
     generate_counterexample: bool
+    per_depth_timeout: float
 
     def __init__(self, args: dict[str, Any]) -> None:
         super().__init__(args)
@@ -376,6 +377,7 @@ class ProveOptions(
             'extra_module': None,
             'symbolic_caller': False,
             'generate_counterexample': False,
+            'per_depth_timeout': 0.0,
         }
 
     @staticmethod

--- a/src/kontrol/prove.py
+++ b/src/kontrol/prove.py
@@ -318,7 +318,28 @@ def _run_cfg_group(
 
     def init_and_run_proof(test: FoundryTest, progress: Progress | None = None) -> APRFailureInfo | Exception | None:
         if options.per_depth_timeout > 0:
-            return _init_and_run_proof_progressive(test, progress)
+            current_depth = max(1, options.max_depth)
+            while True:
+                budget_s = current_depth * options.per_depth_timeout
+                outcome = _run_attempt_under_timeout(test, current_depth, budget_s)
+                if outcome is _attempt_timeout:
+                    _LOGGER.warning(
+                        f'Proof {test.id}: depth={current_depth} attempt exhausted {budget_s}s budget; halving.'
+                    )
+                    if current_depth <= 1:
+                        break
+                    current_depth = max(1, current_depth // 2)
+                    continue
+                return outcome  # type: ignore[no-any-return]
+            # All attempts exhausted; load whatever state was persisted to disk.
+            if Proof.proof_data_exists(test.id, foundry.proofs_dir):
+                persisted = foundry.get_apr_proof(test.id)
+                if persisted.error_info is not None:
+                    return persisted.error_info
+                if persisted.failure_info is not None and not isinstance(persisted.failure_info, APRFailureInfo):
+                    raise RuntimeError('Generated failure info for APRProof is not APRFailureInfo.')
+                return persisted.failure_info
+            return None
 
         task: TaskID | None = None
         if progress is not None:
@@ -485,32 +506,6 @@ def _run_cfg_group(
                 return proof.error_info
             else:
                 return proof.failure_info
-
-    def _init_and_run_proof_progressive(
-        test: FoundryTest, progress: Progress | None
-    ) -> APRFailureInfo | Exception | None:
-        current_depth = max(1, options.max_depth)
-        while True:
-            budget_s = current_depth * options.per_depth_timeout
-            outcome = _run_attempt_under_timeout(test, current_depth, budget_s)
-            if outcome is _attempt_timeout:
-                _LOGGER.warning(
-                    f'Proof {test.id}: depth={current_depth} attempt exhausted {budget_s}s budget; halving.'
-                )
-                if current_depth <= 1:
-                    break
-                current_depth = max(1, current_depth // 2)
-                continue
-            return outcome  # type: ignore[no-any-return]
-        # All attempts exhausted; load whatever state was persisted to disk.
-        if Proof.proof_data_exists(test.id, foundry.proofs_dir):
-            persisted = foundry.get_apr_proof(test.id)
-            if persisted.error_info is not None:
-                return persisted.error_info
-            if persisted.failure_info is not None and not isinstance(persisted.failure_info, APRFailureInfo):
-                raise RuntimeError('Generated failure info for APRProof is not APRFailureInfo.')
-            return persisted.failure_info
-        return None
 
     def _run_attempt_under_timeout(test: FoundryTest, attempt_max_depth: int, budget_s: float) -> Any:
         """Run one prove attempt for `test` at `attempt_max_depth` in a forked subprocess, returning `_attempt_timeout` if `proof_subdir` goes a full `budget_s` window without any file write."""

--- a/src/kontrol/prove.py
+++ b/src/kontrol/prove.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import signal
 import sys
 import time
 from abc import abstractmethod
@@ -10,6 +12,7 @@ from functools import partial
 from subprocess import CalledProcessError
 from typing import TYPE_CHECKING, Any, ContextManager, NamedTuple
 
+import multiprocess as mp  # type: ignore
 from kevm_pyk.cli import EVMChainOptions
 from kevm_pyk.kevm import KEVM, _process_jumpdests
 from kevm_pyk.utils import KDefinition__expand_macros, abstract_cell_vars, run_prover
@@ -311,7 +314,11 @@ def _run_cfg_group(
     summary_ids: Iterable[str],
     init_accounts: Iterable[KInner] = (),
 ) -> list[APRProof]:
+    _attempt_timeout: Any = object()
+
     def init_and_run_proof(test: FoundryTest, progress: Progress | None = None) -> APRFailureInfo | Exception | None:
+        if options.per_depth_timeout > 0:
+            return _init_and_run_proof_progressive(test, progress)
 
         task: TaskID | None = None
         if progress is not None:
@@ -478,6 +485,121 @@ def _run_cfg_group(
                 return proof.error_info
             else:
                 return proof.failure_info
+
+    def _init_and_run_proof_progressive(
+        test: FoundryTest, progress: Progress | None
+    ) -> APRFailureInfo | Exception | None:
+        current_depth = max(1, options.max_depth)
+        while True:
+            budget_s = current_depth * options.per_depth_timeout
+            outcome = _run_attempt_under_timeout(test, current_depth, budget_s)
+            if outcome is _attempt_timeout:
+                _LOGGER.warning(
+                    f'Proof {test.id}: depth={current_depth} attempt exhausted {budget_s}s budget; halving.'
+                )
+                if current_depth <= 1:
+                    break
+                current_depth = max(1, current_depth // 2)
+                continue
+            return outcome  # type: ignore[no-any-return]
+        # All attempts exhausted; load whatever state was persisted to disk.
+        if Proof.proof_data_exists(test.id, foundry.proofs_dir):
+            persisted = foundry.get_apr_proof(test.id)
+            if persisted.error_info is not None:
+                return persisted.error_info
+            if persisted.failure_info is not None and not isinstance(persisted.failure_info, APRFailureInfo):
+                raise RuntimeError('Generated failure info for APRProof is not APRFailureInfo.')
+            return persisted.failure_info
+        return None
+
+    def _run_attempt_under_timeout(test: FoundryTest, attempt_max_depth: int, budget_s: float) -> Any:
+        """Run one prove attempt for `test` at `attempt_max_depth` in a forked subprocess, returning `_attempt_timeout` if `proof_subdir` goes a full `budget_s` window without any file write."""
+        proof_subdir = foundry.proofs_dir / test.id
+
+        def progress_marker() -> float:
+            # Max mtime across proof_subdir; advances each time pyk commits a step (proof.json + KCFG rewritten).
+            marker = 0.0
+            try:
+                for root, _, files in os.walk(proof_subdir):
+                    for fname in files:
+                        try:
+                            marker = max(marker, os.path.getmtime(os.path.join(root, fname)))
+                        except OSError:
+                            continue
+            except OSError:
+                pass
+            return marker
+
+        def _child_entry() -> None:
+            # setsid so the parent's killpg reaps the whole tree (Python + KoreServer + workers).
+            try:
+                os.setsid()
+            except OSError:
+                pass
+            try:
+                options.max_depth = attempt_max_depth
+                options.per_depth_timeout = 0  # prevent re-entering the progressive path
+                result = init_and_run_proof(test, progress=None)
+                try:
+                    child_conn.send(('ok', result))
+                except Exception:
+                    pass
+            except Exception as e:
+                try:
+                    child_conn.send(('err', e))
+                except Exception:
+                    pass
+            finally:
+                try:
+                    child_conn.close()
+                except Exception:
+                    pass
+
+        ctx = mp.get_context('fork')
+        parent_conn, child_conn = ctx.Pipe(duplex=False)
+        proc = ctx.Process(target=_child_entry)
+        proc.start()
+        try:
+            child_conn.close()
+        except Exception:
+            pass
+
+        last_marker = progress_marker()
+        while True:
+            proc.join(timeout=budget_s)
+            if not proc.is_alive():
+                break
+            current_marker = progress_marker()
+            if current_marker != last_marker:
+                last_marker = current_marker
+                continue  # progress observed; grant another budget_s window
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except OSError:
+                pass
+            proc.join()
+            try:
+                parent_conn.close()
+            except Exception:
+                pass
+            return _attempt_timeout
+
+        try:
+            if parent_conn.poll():
+                tag, payload = parent_conn.recv()
+            else:
+                tag, payload = 'ok', None
+        except (EOFError, OSError):
+            tag, payload = 'ok', None
+        finally:
+            try:
+                parent_conn.close()
+            except Exception:
+                pass
+
+        if tag == 'err':
+            _LOGGER.error(f'Proof {test.id} subprocess raised: {payload}')
+        return payload
 
     with Progress(
         SpinnerColumn(),


### PR DESCRIPTION
## Summary

Adds `--per-depth-timeout SECONDS` to `kontrol prove`. Each prove attempt runs in a forked subprocess with `current_depth * per_depth_timeout` seconds as a **stall window**: as long as the proof keeps writing to disk (any file under `proofs_dir/<test.id>` gets a new mtime), the window resets. When a full window passes with no writes, the whole session is SIGKILL'd, `current_depth` is halved (floor 1), and the next attempt resumes from the disk-persisted KCFG. Default `0` disables the wrapper.

Example: `--max-depth 1000 --per-depth-timeout 0.5` → 500s window at depth 1000, halving to 250s @ 500, … 0.5s @ 1.

## Why this shape

- **Stall window, not total budget** — progressive halving exists to detect when `execute_depth` is too coarse to break out of a stuck step. As long as new nodes appear, we leave the proof alone.
- **Subprocess + session SIGKILL, not in-process callback** — `advance_proof`'s maintenance callback only fires after `step_proof` returns. A single long step (deep symbolic execution, expensive SMT) is uninterruptible from inside the prover. Killing the session is the only way to enforce wall-clock regardless of what the prover is doing.

## Implementation

- `cli.py` / `options.py`: new `--per-depth-timeout` flag and `ProveOptions.per_depth_timeout` field (default `0`).
- `prove.py`: when `per_depth_timeout > 0`, `init_and_run_proof` dispatches to `_init_and_run_proof_progressive`, which loops over halving depths via `_run_attempt_under_timeout`:
  - `mp.get_context('fork').Process` → child inherits everything via CoW; child `os.setsid()` so the parent's `killpg` reaps Python + KoreServer + worker threads.
  - Parent calls `proc.join(timeout=budget_s)` then compares max mtime under `proofs_dir/<test.id>` against the previous snapshot. Changed → another window. Unchanged → SIGKILL, halve, retry.

## Test plan

- [x] `kontrol prove --help` lists `--per-depth-timeout` with documented behavior.
- [x] Default-off: `kontrol prove --match-test TokenValueLibProofs.init --max-depth 100` (no `--per-depth-timeout`) passed in 28s; process tree showed a single python + one kore-rpc-booster (no fork), confirming the `run_prover` path is unchanged.
- [x] Stall detection on a real stuck proof (vault-contracts-aave-v4 `test_amountToValueDown`, `--per-depth-timeout 0.5 --max-depth 1000`): observed 10 halvings 1000→1, KCFG advanced 1437 steps in the first attempt then stayed pinned at the deepest unresolvable node — proof stopped exactly where it should.
- [x] No false positives on a productive proof (steady progress completes without being killed).
- [x] Cleanup: after the 10-cycle halving run above, `pgrep kore-rpc-booster` returned 0 — session-group SIGKILL reaped every kore-rpc subprocess across all kill cycles.

## Caveats

- POSIX-only (already a kontrol requirement).
- Each halving spawns a fresh KoreServer (a few seconds startup overhead per attempt).
- `proof.write_proof_data()` is assumed atomic (temp + rename); a SIGKILL mid-write would at worst lose one step.
- Kill latency ≤ one extra `budget_s` window beyond actual stall onset.