### PR TITLE
feat: add `--step-timeout` option for kontrol prove

### DIFF
--- a/src/kontrol/cli.py
+++ b/src/kontrol/cli.py
@@ -576,6 +576,13 @@ def _create_argument_parser() -> ArgumentParser:
         action='store_true',
         help='Generate a Solidity test contract with concrete counterexample values when proofs fail.',
     )
+    prove_args.add_argument(
+        '--step-timeout',
+        type=int,
+        default=None,
+        dest='step_timeout',
+        help='Per-step wall-clock budget in whole seconds; on timeout the backend request is interrupted and the execution depth is halved before retrying. Disabled by default.',
+    )
 
     show_args = command_parser.add_parser(
         'show',

--- a/src/kontrol/options.py
+++ b/src/kontrol/options.py
@@ -350,6 +350,7 @@ class ProveOptions(
     extra_module: str | None
     symbolic_caller: bool
     generate_counterexample: bool
+    step_timeout: int | None
 
     def __init__(self, args: dict[str, Any]) -> None:
         super().__init__(args)
@@ -383,6 +384,7 @@ class ProveOptions(
             'extra_module': None,
             'symbolic_caller': False,
             'generate_counterexample': False,
+            'step_timeout': None,
         }
 
     @staticmethod

--- a/src/kontrol/prove.py
+++ b/src/kontrol/prove.py
@@ -461,6 +461,7 @@ def _run_cfg_group(
                 assume_defined=options.assume_defined,
                 extra_module=lemmas_module,
                 optimize_kcfg=options.optimize_kcfg,
+                step_timeout=options.step_timeout,
             )
 
             if progress is not None and task is not None:


### PR DESCRIPTION
Exposes pyk's per-step timeout through `kontrol prove`.

When `--step-timeout S` is set, each rewrite step gets a wall-clock budget of `S` whole seconds; on timeout the backend request is interrupted, the execution depth is halved, and the step is retried. Default `None` disables it (prior behavior unchanged).

The mechanism lives in pyk's `APRProver` (runtimeverification/k#4930) and is threaded through `run_prover` (runtimeverification/evm-semantics#2867, in kevm-pyk v1.0.921, already pinned on master). This PR only wires the CLI option → `ProveOptions` → `run_prover`.

Note: `step_timeout` is only enforced on the sequential `advance_proof` path, so `run_prover` runs sequentially when it is set, warning if `max_frontier_parallel > 1`. Making the parallel path honor it is a pyk follow-up.

## Testing

- `kontrol prove --help` shows `--step-timeout`.
- Verified end-to-end against the pinned deps: `ProveOptions` carries `step_timeout`, and both `kevm_pyk.utils.run_prover` and pyk `APRProver` accept it.